### PR TITLE
docs/eval: temporal export history + trend report (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,3 +200,13 @@ ops.verify:
 # Identical to local; intentionally not part of CI
 ci.ops.verify:
 	@python3 scripts/ops/verify_repo.py
+
+.PHONY: eval.history ci.eval.history
+
+# Temporal export history (writes share/eval/history.{json,md})
+eval.history:
+	@python3 scripts/eval/report_history.py
+
+# Not wired into CI; identical to local for now
+ci.eval.history:
+	@python3 scripts/eval/report_history.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -14,6 +14,23 @@ Local-only evaluation flow. No CI gates or `make go` changes.
    * `share/eval/report.json`
    * `share/eval/report.md`
 
+### Temporal history (local-only)
+Run:
+```bash
+make eval.history
+```
+
+Artifacts:
+
+* `share/eval/history.json` — per-export metrics + summary
+* `share/eval/history.md` — human-readable trend table and OK badge
+
+Notes:
+
+* Files matched: `exports/graph_*.json`
+* Sorting prefers timestamp in filename; minimal fallback
+* Checks: nonzero nodes/edges, strength fraction in [0.30, 0.95] ≥ 0.70, embedding_dim==1024 when present
+
 ## Notes
 
 * Deterministic and fast; suited for PR evidence.

--- a/eval/manifest.yml
+++ b/eval/manifest.yml
@@ -1,4 +1,4 @@
-version: 0.2
+version: 0.3
 run_id: local-dev
 tasks:
   - key: smoke_hello
@@ -12,13 +12,17 @@ tasks:
       file: "docs/SSOT/RULES_INDEX.md"
       patterns: ["037", "038"]
 
-  - key: exports_presence
+  - key: exports_presence_latest
     kind: file_glob
     args:
-      globs:
-        - "exports/graph_latest.json"
+      globs: ["exports/graph_latest.json"]
 
-  - key: exports_edge_strength_spread
+  - key: exports_presence_all
+    kind: file_glob
+    args:
+      globs: ["exports/graph_*.json"]
+
+  - key: exports_edge_strength_spread_latest
     kind: json_assert
     args:
       file: "exports/graph_latest.json"
@@ -28,9 +32,9 @@ tasks:
           op: "frac_in_range"
           min: 0.30
           max: 0.95
-          min_frac: 0.70  # allow some outliers; policy target ≈0.3–0.95
+          min_frac: 0.70
 
-  - key: exports_nodes_dim_if_present
+  - key: exports_nodes_dim_if_present_latest
     kind: json_assert
     args:
       file: "exports/graph_latest.json"

--- a/scripts/eval/report_history.py
+++ b/scripts/eval/report_history.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+import glob
+import json
+import pathlib
+import re
+import sys
+import time
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUTDIR = ROOT / "share" / "eval"
+JSON_OUT = OUTDIR / "history.json"
+MD_OUT = OUTDIR / "history.md"
+
+EXPORT_GLOB = str(ROOT / "exports" / "graph_*.json")
+
+
+def _load_json(p: pathlib.Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _parse_ts_from_name(name: str) -> tuple[int, str]:
+    base = pathlib.Path(name).name
+    m = re.search(r"graph_(\d{4}-?\d{2}-?\d{2})[T_]?(\d{2}-?\d{2}-?\d{2})?Z?", base)
+    if m:
+        d = m.group(1).replace("-", "")
+        t = (m.group(2) or "000000").replace("-", "")
+        try:
+            return (int(d + t), base)
+        except Exception:
+            pass
+    m2 = re.search(r"graph_(\d{8})(\d{6})?", base)
+    if m2:
+        d = m2.group(1)
+        t = m2.group(2) or "000000"
+        return (int(d + t), base)
+    # fallback to mtime sort
+    return (0, base)
+
+
+def _summarize_file(p: pathlib.Path) -> dict[str, Any]:
+    doc = _load_json(p)
+    edges = doc.get("edges", [])
+    nodes = doc.get("nodes", [])
+
+    # Handle case where edges is an integer (stats files) vs array (graph files)
+    if isinstance(edges, int):
+        edge_count = edges
+        strengths = []
+    elif isinstance(edges, list):
+        edge_count = len(edges)
+        strengths = [e.get("strength") for e in edges if isinstance(e, dict)]
+    else:
+        edge_count = 0
+        strengths = []
+
+    nums = [float(x) for x in strengths if isinstance(x, (int, float))]
+    in_range = [x for x in nums if 0.30 <= x <= 0.95]
+    frac = len(in_range) / max(1, len(nums))
+
+    # Handle case where nodes is an integer (stats files) vs array (graph files)
+    if isinstance(nodes, int):
+        node_count = nodes
+        dim_vals = []
+    elif isinstance(nodes, list):
+        node_count = len(nodes)
+        dim_vals = [n.get("embedding_dim") for n in nodes if isinstance(n, dict)]
+    else:
+        node_count = 0
+        dim_vals = []
+
+    dim_present = [v for v in dim_vals if v is not None]
+    dim_ok = all(v == 1024 for v in dim_present) if dim_present else True
+    return {
+        "file": str(p.relative_to(ROOT)),
+        "nodes": node_count,
+        "edges": edge_count,
+        "strength": {"count": len(nums), "ok_frac_0.30_0.95": round(frac, 4)},
+        "embedding_dim_if_present_1024": dim_ok,
+    }
+
+
+def main() -> int:
+    print("[eval.history] starting")
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(glob.glob(EXPORT_GLOB), key=_parse_ts_from_name)
+    if not files:
+        JSON_OUT.write_text(
+            json.dumps({"results": [], "summary": {"series_n": 0}}, indent=2),
+            encoding="utf-8",
+        )
+        MD_OUT.write_text(
+            "# Gemantria Export History\n\n_No exports found._\n", encoding="utf-8"
+        )
+        print(f"[eval.history] wrote {JSON_OUT.relative_to(ROOT)}")
+        print(f"[eval.history] wrote {MD_OUT.relative_to(ROOT)}")
+        print("[eval.history] DONE_WITH_EMPTY")
+        return 0
+
+    # Filter to only files that have actual graph data (arrays, not just counts)
+    graph_files = []
+    for f in files:
+        try:
+            doc = _load_json(pathlib.Path(f))
+            nodes = doc.get("nodes", [])
+            edges = doc.get("edges", [])
+            # Only include files where nodes/edges are arrays with content
+            if (
+                isinstance(nodes, list)
+                and isinstance(edges, list)
+                and len(nodes) > 0
+                and len(edges) > 0
+            ):
+                graph_files.append(f)
+        except Exception:
+            continue
+
+    if not graph_files:
+        JSON_OUT.write_text(
+            json.dumps({"results": [], "summary": {"series_n": 0}}, indent=2),
+            encoding="utf-8",
+        )
+        MD_OUT.write_text(
+            "# Gemantria Export History\n\n_No valid graph exports found._\n",
+            encoding="utf-8",
+        )
+        print(f"[eval.history] wrote {JSON_OUT.relative_to(ROOT)}")
+        print(f"[eval.history] wrote {MD_OUT.relative_to(ROOT)}")
+        print("[eval.history] DONE_WITH_EMPTY")
+        return 0
+
+    series = [_summarize_file(pathlib.Path(f)) for f in graph_files]
+    ok = all(
+        [
+            all(item["nodes"] > 0 for item in series),
+            all(item["edges"] > 0 for item in series),
+            all(item["strength"]["ok_frac_0.30_0.95"] >= 0.70 for item in series),
+            all(item["embedding_dim_if_present_1024"] for item in series),
+        ]
+    )
+
+    report = {
+        "ts_unix": int(time.time()),
+        "summary": {
+            "series_n": len(series),
+            "ok_all": ok,
+            "nodes_nonzero_all": all(item["nodes"] > 0 for item in series),
+            "edges_nonzero_all": all(item["edges"] > 0 for item in series),
+            "ok_frac_threshold": 0.70,
+        },
+        "results": series,
+    }
+    JSON_OUT.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    lines = []
+    lines.append("# Gemantria Export History")
+    lines.append("")
+    lines.append(f"*series:* {len(series)}  •  *ok:* {'✅' if ok else '❌'}")
+    lines.append("")
+    lines.append(
+        "| file | nodes | edges | strength ok frac (0.30–0.95) | dims ok (if present) |"
+    )
+    lines.append("|---|---:|---:|---:|:---:|")
+    for item in series:
+        lines.append(
+            f"| {item['file']} | {item['nodes']} | {item['edges']} | {item['strength']['ok_frac_0.30_0.95']} | {'✅' if item['embedding_dim_if_present_1024'] else '❌'} |"
+        )
+    lines.append("")
+    MD_OUT.write_text("\n".join(lines), encoding="utf-8")
+
+    print(f"[eval.history] wrote {JSON_OUT.relative_to(ROOT)}")
+    print(f"[eval.history] wrote {MD_OUT.relative_to(ROOT)}")
+    print("[eval.history] OK" if ok else "[eval.history] DONE_WITH_FAILS")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary by Sourcery

Implement a local-only temporal export history feature by extending the eval manifest, adding a report_history script, new make targets, and documenting the workflow.

New Features:
- Add make eval.history and ci.eval.history targets for temporal export history reporting
- Introduce scripts/eval/report_history.py to summarize export series into JSON and markdown trend reports

Enhancements:
- Bump eval manifest version to 0.3 and rename/add tasks for latest and all export file checks

Documentation:
- Document the temporal history workflow in PHASE8_EVAL.md with usage instructions and artifact details

Chores:
- Update Makefile to include new .PHONY targets for eval.history