### PR TITLE
docs/eval: add json schema validation + delta report (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,3 +210,13 @@ eval.history:
 # Not wired into CI; identical to local for now
 ci.eval.history:
 	@python3 scripts/eval/report_history.py
+
+.PHONY: eval.delta ci.eval.delta
+
+# Per-run delta report (writes share/eval/delta.{json,md})
+eval.delta:
+	@python3 scripts/eval/report_delta.py
+
+# Not wired into CI; identical to local for now
+ci.eval.delta:
+	@python3 scripts/eval/report_delta.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -31,6 +31,24 @@ Notes:
 * Sorting prefers timestamp in filename; minimal fallback
 * Checks: nonzero nodes/edges, strength fraction in [0.30, 0.95] ≥ 0.70, embedding_dim==1024 when present
 
+### Schema validation (local-only)
+`eval.report` now supports a `json_schema` task kind using a repo-local schema:
+- Schema path: `docs/SSOT/schemas/graph_export.schema.json`
+- Local dependency: `pip install jsonschema`
+- Run: `make eval.report` — the task key `exports_schema_validate_latest` must be ✅
+
+### Per-run delta (local-only)
+Run:
+```bash
+make eval.delta
+```
+
+Artifacts:
+
+* `share/eval/delta.json` — added/removed nodes/edges + strength stats
+* `share/eval/delta.md` — human-readable summary
+  Policy (initial): **no removals** (nodes/edges) for an ✅ badge. Tolerances can be relaxed in a future PR.
+
 ## Notes
 
 * Deterministic and fast; suited for PR evidence.

--- a/docs/SSOT/schemas/graph_export.schema.json
+++ b/docs/SSOT/schemas/graph_export.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Gemantria Graph Export",
+  "type": "object",
+  "required": ["nodes", "edges"],
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "anyOf": [{"type": "string"}, {"type": "integer"}] },
+          "label": { "type": ["string", "null"] },
+          "embedding_dim": { "type": ["integer", "null"] },
+          "meta": { "type": ["object", "null"] }
+        },
+        "additionalProperties": true
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "target"],
+        "properties": {
+          "source": { "anyOf": [{"type": "string"}, {"type": "integer"}] },
+          "target": { "anyOf": [{"type": "string"}, {"type": "integer"}] },
+          "strength": { "type": ["number", "null"], "minimum": 0.0, "maximum": 1.0 },
+          "rerank":   { "type": ["number", "null"], "minimum": 0.0, "maximum": 1.0 },
+          "meta":     { "type": ["object", "null"] }
+        },
+        "additionalProperties": true
+      }
+    },
+    "meta": { "type": ["object", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/eval/manifest.yml
+++ b/eval/manifest.yml
@@ -1,4 +1,4 @@
-version: 0.3
+version: 0.4
 run_id: local-dev
 tasks:
   - key: smoke_hello
@@ -43,6 +43,12 @@ tasks:
           path: "nodes[*].embedding_dim"
           op: "if_present_eq_all"
           value: 1024
+
+  - key: exports_schema_validate_latest
+    kind: json_schema
+    args:
+      file: "exports/graph_latest.json"
+      schema: "docs/SSOT/schemas/graph_export.schema.json"
 
 success_policy:
   mode: all_must_pass

--- a/scripts/eval/report_delta.py
+++ b/scripts/eval/report_delta.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import glob
+import json
+import pathlib
+import re
+import sys
+import time
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUTDIR = ROOT / "share" / "eval"
+JSON_OUT = OUTDIR / "delta.json"
+MD_OUT = OUTDIR / "delta.md"
+
+EXPORT_DIR = ROOT / "exports"
+LATEST = EXPORT_DIR / "graph_latest.json"
+
+
+def _load_json(p: pathlib.Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _parse_ts(name: str) -> int:
+    base = pathlib.Path(name).name
+    m = re.search(r"graph_(\d{8})(\d{6})?", base)
+    if m:
+        d = m.group(1)
+        t = m.group(2) or "000000"
+        return int(d + t)
+    m2 = re.search(r"graph_(\d{4}-\d{2}-\d{2})[T_]?(\d{2}-\d{2}-\d{2})?", base)
+    if m2:
+        d = m2.group(1).replace("-", "")
+        t = (m2.group(2) or "00-00-00").replace("-", "")
+        return int(d + t)
+    return 0
+
+
+def _edge_key(e: dict[str, Any]) -> tuple[Any, Any]:
+    return (e.get("source"), e.get("target"))
+
+
+def _node_ids(doc: dict[str, Any]) -> set[Any]:
+    nodes = doc.get("nodes", [])
+    if isinstance(nodes, list):
+        return {n.get("id") for n in nodes if isinstance(n, dict) and "id" in n}
+    return set()
+
+
+def _edge_pairs(doc: dict[str, Any]) -> set[tuple[Any, Any]]:
+    edges = doc.get("edges", [])
+    if isinstance(edges, list):
+        return {_edge_key(e) for e in edges if isinstance(e, dict)}
+    return set()
+
+
+def _strengths(doc: dict[str, Any]) -> list[float]:
+    edges = doc.get("edges", [])
+    vals: list[float] = []
+    if isinstance(edges, list):
+        for e in edges:
+            v = e.get("strength")
+            if isinstance(v, (int, float)):
+                vals.append(float(v))
+    return vals
+
+
+def main() -> int:
+    print("[eval.delta] starting")
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+
+    if not LATEST.exists():
+        print("[eval.delta] FAIL no exports/graph_latest.json")
+        return 2
+
+    # pick most recent prior export (graph_*.json excluding latest path)
+    candidates = [p for p in glob.glob(str(EXPORT_DIR / "graph_*.json"))]
+    # exclude graph_latest.json if it matches pattern on some setups
+    candidates = [c for c in candidates if pathlib.Path(c).name != "graph_latest.json"]
+    if not candidates:
+        # Write empty delta artifacts but succeed deterministically
+        report = {"summary": {"has_previous": False}}
+        JSON_OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        MD_OUT.write_text(
+            "# Gemantria Export Delta\n\n_No previous export found._\n",
+            encoding="utf-8",
+        )
+        print(f"[eval.delta] wrote {JSON_OUT.relative_to(ROOT)}")
+        print(f"[eval.delta] wrote {MD_OUT.relative_to(ROOT)}")
+        print("[eval.delta] OK")
+        return 0
+
+    prev_fp = sorted(candidates, key=_parse_ts)[-1]
+    prev_path = pathlib.Path(prev_fp)
+
+    cur = _load_json(LATEST)
+    prev = _load_json(prev_path)
+
+    cur_nodes = _node_ids(cur)
+    prev_nodes = _node_ids(prev)
+    cur_edges = _edge_pairs(cur)
+    prev_edges = _edge_pairs(prev)
+
+    added_nodes = sorted(list(cur_nodes - prev_nodes))
+    removed_nodes = sorted(list(prev_nodes - cur_nodes))
+    added_edges = sorted(list(cur_edges - prev_edges))
+    removed_edges = sorted(list(prev_edges - cur_edges))
+
+    cur_strengths = _strengths(cur)
+    prev_strengths = _strengths(prev)
+
+    def _stats(arr: list[float]) -> dict[str, Any]:
+        if not arr:
+            return {"count": 0}
+        return {
+            "count": len(arr),
+            "min": min(arr),
+            "max": max(arr),
+            "mean": sum(arr) / len(arr),
+        }
+
+    cur_stats = _stats(cur_strengths)
+    prev_stats = _stats(prev_strengths)
+
+    # Simple policy: no removals allowed by default; can be relaxed later.
+    ok = (len(removed_nodes) == 0) and (len(removed_edges) == 0)
+
+    report = {
+        "ts_unix": int(time.time()),
+        "summary": {
+            "has_previous": True,
+            "ok": ok,
+            "removed_nodes": len(removed_nodes),
+            "removed_edges": len(removed_edges),
+        },
+        "previous_file": str(prev_path.relative_to(ROOT)),
+        "current_file": str(LATEST.relative_to(ROOT)),
+        "nodes": {"added": added_nodes, "removed": removed_nodes},
+        "edges": {"added": added_edges, "removed": removed_edges},
+        "strength_stats": {"current": cur_stats, "previous": prev_stats},
+    }
+    JSON_OUT.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    lines = []
+    lines.append("# Gemantria Export Delta")
+    lines.append("")
+    lines.append(f"*previous:* `{report['previous_file']}`")
+    lines.append(f"*current:*  `{report['current_file']}`")
+    lines.append("")
+    lines.append(
+        f"*removed_nodes:* {len(removed_nodes)}  •  *removed_edges:* {len(removed_edges)}  •  *ok:* {'✅' if ok else '❌'}"
+    )
+    lines.append("")
+    lines.append("## Strength stats")
+    lines.append("```json")
+    lines.append(json.dumps(report["strength_stats"], indent=2, sort_keys=True))
+    lines.append("```")
+    lines.append("")
+    lines.append("## Added/Removed (node ids, edge pairs)")
+    lines.append("```json")
+    lines.append(
+        json.dumps(
+            {"nodes": report["nodes"], "edges": report["edges"]},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    lines.append("```")
+    lines.append("")
+    MD_OUT.write_text("\n".join(lines), encoding="utf-8")
+
+    print(f"[eval.delta] wrote {JSON_OUT.relative_to(ROOT)}")
+    print(f"[eval.delta] wrote {MD_OUT.relative_to(ROOT)}")
+    print("[eval.delta] OK" if ok else "[eval.delta] DONE_WITH_FAILS")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary by Sourcery

Implement JSON-based validation tasks in eval.report, update the eval manifest version, and introduce a local-only delta report generator with Makefile integration and updated documentation

New Features:
- Add JSON schema validation task kind to eval.report
- Add JSON assertion task kind supporting not_null_all, frac_in_range, and if_present_eq_all operations
- Add file_glob task kind for checking file patterns
- Introduce a delta report generator (scripts/eval/report_delta.py) with accompanying Makefile targets

Enhancements:
- Refactor YAML loading in eval.report and bump eval manifest version to 0.4

Build:
- Add Makefile targets eval.delta and ci.eval.delta for delta reporting

Documentation:
- Update PHASE8_EVAL.md with schema validation and delta report instructions
- Add graph_export.schema.json to docs/SSOT as the JSON schema file