### PR TITLE
docs/eval: thresholds substitution + shape smoke + eval index (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,3 +220,12 @@ eval.delta:
 # Not wired into CI; identical to local for now
 ci.eval.delta:
 	@python3 scripts/eval/report_delta.py
+
+.PHONY: eval.index ci.eval.index
+
+# Build a simple index of eval artifacts
+eval.index:
+	@python3 scripts/eval/build_index.py
+
+ci.eval.index:
+	@python3 scripts/eval/build_index.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -49,6 +49,24 @@ Artifacts:
 * `share/eval/delta.md` — human-readable summary
   Policy (initial): **no removals** (nodes/edges) for an ✅ badge. Tolerances can be relaxed in a future PR.
 
+### Thresholds (local-only)
+Centralized in `eval/thresholds.yml`. The eval engine substitutes `${thresholds:...}` in `eval/manifest.yml` before running.
+Examples:
+- `${thresholds:strength.min}` / `${thresholds:strength.max}` / `${thresholds:strength.min_frac}`
+- `${thresholds:embedding.dim_if_present}`
+- `${thresholds:shape.nodes.min}` / `${thresholds:shape.edges.max}`
+
+### Shape smoke
+Task kind `json_shape` verifies node/edge counts within bounds. See task `exports_shape_smoke_latest`.
+
+### Eval index
+Run:
+```bash
+make eval.index
+```
+
+Artifact: `share/eval/index.md` — quick links/badges for `report.md`, `history.md`, `delta.md`.
+
 ## Notes
 
 * Deterministic and fast; suited for PR evidence.

--- a/eval/manifest.yml
+++ b/eval/manifest.yml
@@ -1,4 +1,4 @@
-version: 0.4
+version: 0.5
 run_id: local-dev
 tasks:
   - key: smoke_hello
@@ -27,28 +27,37 @@ tasks:
     args:
       file: "exports/graph_latest.json"
       asserts:
-        - name: "edge strength fraction in [0.30,0.95]"
+        - name: "edge strength fraction in [min,max]"
           path: "edges[*].strength"
           op: "frac_in_range"
-          min: 0.30
-          max: 0.95
-          min_frac: 0.70
+          min: "${thresholds:strength.min}"
+          max: "${thresholds:strength.max}"
+          min_frac: "${thresholds:strength.min_frac}"
 
   - key: exports_nodes_dim_if_present_latest
     kind: json_assert
     args:
       file: "exports/graph_latest.json"
       asserts:
-        - name: "nodes[*].embedding_dim==1024 if present"
+        - name: "nodes[*].embedding_dim==dim_if_present if present"
           path: "nodes[*].embedding_dim"
           op: "if_present_eq_all"
-          value: 1024
+          value: "${thresholds:embedding.dim_if_present}"
 
   - key: exports_schema_validate_latest
     kind: json_schema
     args:
       file: "exports/graph_latest.json"
       schema: "docs/SSOT/schemas/graph_export.schema.json"
+
+  - key: exports_shape_smoke_latest
+    kind: json_shape
+    args:
+      file: "exports/graph_latest.json"
+      min_nodes: "${thresholds:shape.nodes.min}"
+      max_nodes: "${thresholds:shape.nodes.max}"
+      min_edges: "${thresholds:shape.edges.min}"
+      max_edges: "${thresholds:shape.edges.max}"
 
 success_policy:
   mode: all_must_pass

--- a/eval/thresholds.yml
+++ b/eval/thresholds.yml
@@ -1,0 +1,17 @@
+version: 1
+strength:
+  min: 0.30
+  max: 0.95
+  min_frac: 0.70   # fraction of edges within [min,max] required
+shape:
+  nodes:
+    min: 1
+    max: 10000000
+  edges:
+    min: 1
+    max: 10000000
+embedding:
+  dim_if_present: 1024
+delta:
+  allow_removed_nodes: 0
+  allow_removed_edges: 0

--- a/scripts/eval/build_index.py
+++ b/scripts/eval/build_index.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import pathlib
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVAL = ROOT / "share" / "eval"
+OUT = EVAL / "index.md"
+
+
+def main() -> int:
+    print("[eval.index] starting")
+    EVAL.mkdir(parents=True, exist_ok=True)
+    artifacts = [
+        ("report.md", "Latest manifest report"),
+        ("history.md", "Temporal history/trend"),
+        ("delta.md", "Delta (latest vs previous)"),
+    ]
+    lines = []
+    lines.append("# Gemantria Eval — Artifacts Index")
+    lines.append("")
+    lines.append(f"*generated:* {int(time.time())}")
+    lines.append("")
+    for fn, label in artifacts:
+        p = EVAL / fn
+        exists = p.exists()
+        badge = "✅" if exists else "❌"
+        lines.append(f"- {badge} **{label}** — {fn if exists else '(missing)'}")
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.index] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.index] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable thresholds, add JSON shape smoke testing and an evaluation artifacts index

New Features:
- Support loading and substituting thresholds from eval/thresholds.yml in the manifest
- Add a json_shape task to verify node and edge count constraints in JSON exports
- Introduce build_index.py and Makefile targets to generate a markdown index of evaluation artifacts

Enhancements:
- Bump eval manifest version to 0.5 and replace hardcoded threshold values with ${thresholds:...} placeholders

Build:
- Add eval.index and ci.eval.index targets to the Makefile

Documentation:
- Update PHASE8_EVAL.md with sections on thresholds substitution, shape smoke testing, and the eval index