### PR TITLE
docs/eval: exports catalog + one-shot local reproducer (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,3 +238,12 @@ eval.idstability:
 
 ci.eval.idstability:
 	@python3 scripts/eval/report_id_stability.py
+
+.PHONY: eval.catalog ci.eval.catalog
+
+# Build an exports catalog (writes share/eval/exports_catalog.md)
+eval.catalog:
+	@python3 scripts/eval/build_exports_catalog.py
+
+ci.eval.catalog:
+	@python3 scripts/eval/build_exports_catalog.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -83,6 +83,26 @@ Artifacts:
 * `share/eval/id_stability.md` — summary with badge
   Thresholds in `eval/thresholds.yml` under `id_stability.*`.
 
+### Exports catalog (local-only)
+Run:
+```bash
+make eval.catalog
+```
+
+Artifact:
+
+* `share/eval/exports_catalog.md` — size + node/edge counts for every `exports/graph_*.json`.
+
+### One-shot reproducer (local-only)
+
+Run:
+
+```bash
+bash scripts/eval/repro_local.sh
+```
+
+Runs: report → history → delta → idstability → index → catalog (local-only).
+
 ### Referential integrity (local-only)
 Task kind `ref_integrity` checks that edges reference existing node ids, and enforces limits on self-loops and duplicates.
 Thresholds come from `eval/thresholds.yml` (integrity.*). See task `exports_ref_integrity_latest`.

--- a/scripts/eval/build_exports_catalog.py
+++ b/scripts/eval/build_exports_catalog.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import glob
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUT = ROOT / "share" / "eval" / "exports_catalog.md"
+
+
+def _load_json(p: pathlib.Path):
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _summ(p: pathlib.Path):
+    try:
+        doc = _load_json(p)
+        nodes = doc.get("nodes", [])
+        edges = doc.get("edges", [])
+        return len(nodes) if isinstance(nodes, list) else 0, (
+            len(edges) if isinstance(edges, list) else 0
+        )
+    except Exception:
+        return 0, 0
+
+
+def main():
+    print("[eval.catalog] starting")
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    files = sorted(glob.glob(str(ROOT / "exports" / "graph_*.json")))
+    lines = ["# Gemantria Exports Catalog", ""]
+    if not files:
+        lines.append("_No exports found._")
+    else:
+        lines.append("| file | size (KB) | nodes | edges |")
+        lines.append("|---|---:|---:|---:|")
+        for f in files:
+            p = pathlib.Path(f)
+            kb = round(p.stat().st_size / 1024, 1)
+            n, e = _summ(p)
+            lines.append(f"| exports/{p.name} | {kb} | {n} | {e} |")
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.catalog] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.catalog] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/repro_local.sh
+++ b/scripts/eval/repro_local.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[repro] starting"
+make eval.report
+make eval.history
+make eval.delta
+make eval.idstability
+make eval.index
+make eval.catalog
+echo "[repro] OK"


### PR DESCRIPTION
Adds catalog generator, reproducer script, make target, docs. No CI/order changes.

## Summary by Sourcery

Add local-only exports catalog generation and a one-shot reproducer for the evaluation workflow, including supporting scripts, Makefile targets, CI integration, and documentation.

New Features:
- Add a script and Make targets to generate an exports catalog with file sizes and graph metrics
- Introduce a one-shot local reproducer script to run the full evaluation pipeline
- Expose a CI target for exports catalog generation

Documentation:
- Update PHASE8_EVAL.md with instructions for the exports catalog and local reproducer