### PR TITLE
docs/eval: add provenance + checksums; enrich eval index (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,3 +247,19 @@ eval.catalog:
 
 ci.eval.catalog:
 	@python3 scripts/eval/build_exports_catalog.py
+
+.PHONY: eval.provenance ci.eval.provenance eval.checksums ci.eval.checksums
+
+# Provenance (writes share/eval/provenance.{json,md})
+eval.provenance:
+	@python3 scripts/eval/provenance.py
+
+ci.eval.provenance:
+	@python3 scripts/eval/provenance.py
+
+# Checksums for exports (writes share/eval/checksums.csv)
+eval.checksums:
+	@python3 scripts/eval/build_checksums.py
+
+ci.eval.checksums:
+	@python3 scripts/eval/build_checksums.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -112,3 +112,28 @@ Thresholds come from `eval/thresholds.yml` (integrity.*). See task `exports_ref_
 * Deterministic and fast; suited for PR evidence.
 * Do **not** wire into CI until stabilized.
 * Governance: 037/038 unchanged; share drift remains read-only in CI.
+
+### Provenance (local-only)
+Run:
+```bash
+make eval.provenance
+```
+
+Artifacts:
+
+* `share/eval/provenance.json` — git SHA, manifest/thresholds versions, latest export info
+* `share/eval/provenance.md` — human-readable summary
+
+### Checksums (local-only)
+
+Run:
+
+```bash
+make eval.checksums
+```
+
+Artifact:
+
+* `share/eval/checksums.csv` — sha256 + size for each `exports/graph_*.json`
+
+> After generating, re-run `make eval.index` to add badges for these artifacts.

--- a/scripts/eval/build_checksums.py
+++ b/scripts/eval/build_checksums.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import glob
+import hashlib
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUT = ROOT / "share" / "eval" / "checksums.csv"
+
+
+def _sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    print("[eval.checksums] starting")
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    files = sorted(glob.glob(str(ROOT / "exports" / "graph_*.json")))
+    lines = ["sha256,bytes,file"]
+    for f in files:
+        p = pathlib.Path(f)
+        lines.append(f"{_sha256(p)},{p.stat().st_size},exports/{p.name}")
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.checksums] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.checksums] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/build_index.py
+++ b/scripts/eval/build_index.py
@@ -14,6 +14,8 @@ def main() -> int:
         ("report.md", "Latest manifest report"),
         ("history.md", "Temporal history/trend"),
         ("delta.md", "Delta (latest vs previous)"),
+        ("provenance.md", "Provenance"),
+        ("checksums.csv", "Checksums"),
     ]
     lines = []
     lines.append("# Gemantria Eval — Artifacts Index")

--- a/scripts/eval/provenance.py
+++ b/scripts/eval/provenance.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import glob
+import hashlib
+import json
+import pathlib
+import subprocess
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUTDIR = ROOT / "share" / "eval"
+JSON_OUT = OUTDIR / "provenance.json"
+MD_OUT = OUTDIR / "provenance.md"
+
+
+def _git(cmd: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(["git"] + cmd, cwd=ROOT).decode("utf-8").strip()
+    except Exception:
+        return None
+
+
+def _sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    print("[eval.provenance] starting")
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+
+    manifest = ROOT / "eval" / "manifest.yml"
+    thresholds = ROOT / "eval" / "thresholds.yml"
+    latest = ROOT / "exports" / "graph_latest.json"
+    cand = sorted(glob.glob(str(ROOT / "exports" / "graph_*.json")))
+    exports = [pathlib.Path(c) for c in cand]
+
+    repo = {
+        "git_head": _git(["rev-parse", "HEAD"]),
+        "git_branch": _git(["rev-parse", "--abbrev-ref", "HEAD"]),
+        "ts_unix": int(time.time()),
+    }
+
+    man_ver = None
+    if manifest.exists():
+        for line in manifest.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.strip().startswith("version:"):
+                man_ver = line.split(":", 1)[1].strip()
+                break
+
+    thr_ver = None
+    if thresholds.exists():
+        for line in thresholds.read_text(
+            encoding="utf-8", errors="ignore"
+        ).splitlines():
+            if line.strip().startswith("version:"):
+                thr_ver = line.split(":", 1)[1].strip()
+                break
+
+    latest_info = None
+    if latest.exists():
+        latest_info = {
+            "path": str(latest.relative_to(ROOT)),
+            "size_bytes": latest.stat().st_size,
+            "sha256": _sha256(latest),
+        }
+
+    total_size = sum(p.stat().st_size for p in exports) if exports else 0
+    exports_data = {
+        "count": len(exports),
+        "total_size_bytes": total_size,
+        "latest": latest_info,
+    }
+    prov = {
+        "repo": repo,
+        "manifest_version": man_ver,
+        "thresholds_version": thr_ver,
+        "exports": exports_data,
+    }
+
+    JSON_OUT.write_text(json.dumps(prov, indent=2, sort_keys=True), encoding="utf-8")
+
+    lines = []
+    lines.append("# Gemantria Eval Provenance")
+    lines.append("")
+    lines.append(f"*git:* `{repo['git_head']}`  •  *branch:* `{repo['git_branch']}`")
+    lines.append(f"*manifest_version:* {man_ver}  •  *thresholds_version:* {thr_ver}")
+    lines.append(
+        f"*exports:* count={exports_data['count']}  •  "
+        f"total_size_bytes={exports_data['total_size_bytes']}"
+    )
+    if latest_info:
+        lines.append(
+            f"*latest:* `{latest_info['path']}`  •  sha256={latest_info['sha256']}"
+        )
+    lines.append("")
+    MD_OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"[eval.provenance] wrote {JSON_OUT.relative_to(ROOT)}")
+    print(f"[eval.provenance] wrote {MD_OUT.relative_to(ROOT)}")
+    print("[eval.provenance] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds provenance & checksums generators, Make targets, and index enrichment. No CI/order changes.

## Summary by Sourcery

Enable local-only generation of exports catalogs, provenance records, and checksums via new scripts and Make targets, and document these additions in the eval index and PHASE8_EVAL guide.

New Features:
- Add Make targets and CI aliases for generating an exports catalog, provenance data, and checksums
- Introduce scripts for building the exports catalog, computing provenance, calculating checksums, and running a one-shot local reproducer

Enhancements:
- Enrich the evaluation index to include provenance and checksum artifacts
- Extend Makefile to wire new eval tasks into the build system

Documentation:
- Update PHASE8_EVAL.md with sections for exports catalog, one-shot reproducer, provenance, and checksums