### PR TITLE
docs/eval: anomalies aggregator + append-only run log (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,3 +263,19 @@ eval.checksums:
 
 ci.eval.checksums:
 	@python3 scripts/eval/build_checksums.py
+
+.PHONY: eval.anomalies ci.eval.anomalies eval.runlog ci.eval.runlog
+
+# Aggregate anomalies into a single markdown file
+eval.anomalies:
+	@python3 scripts/eval/anomalies.py
+
+ci.eval.anomalies:
+	@python3 scripts/eval/anomalies.py
+
+# Append one JSON line capturing the latest run's artifacts
+eval.runlog:
+	@python3 scripts/eval/run_log.py
+
+ci.eval.runlog:
+	@python3 scripts/eval/run_log.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -137,3 +137,25 @@ Artifact:
 * `share/eval/checksums.csv` — sha256 + size for each `exports/graph_*.json`
 
 > After generating, re-run `make eval.index` to add badges for these artifacts.
+
+### Anomalies (local-only)
+Run:
+```bash
+make eval.anomalies
+```
+
+Artifact:
+
+* `share/eval/anomalies.md` — consolidated red flags from report/history/delta/id_stability.
+
+### Run log (local-only)
+
+Run:
+
+```bash
+make eval.runlog
+```
+
+Artifact:
+
+* `share/eval/run_log.jsonl` — append-only JSONL; each line captures provenance + results snapshot.

--- a/scripts/eval/anomalies.py
+++ b/scripts/eval/anomalies.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import time
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVAL = ROOT / "share" / "eval"
+OUT = EVAL / "anomalies.md"
+
+
+def _load(p: pathlib.Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else None
+
+
+def main() -> int:
+    print("[eval.anomalies] starting")
+    EVAL.mkdir(parents=True, exist_ok=True)
+    report = _load(EVAL / "report.json") or {}
+    history = _load(EVAL / "history.json") or {}
+    delta = _load(EVAL / "delta.json") or {}
+    idstab = _load(EVAL / "id_stability.json") or {}
+
+    lines = []
+    lines.append("# Gemantria Eval — Anomalies")
+    lines.append("")
+    lines.append(f"*generated:* {int(time.time())}")
+    lines.append("")
+
+    # 1) Manifest tasks: list FAIL tasks (if any)
+    fail = []
+    for r in report.get("results") or []:
+        if r.get("status") != "OK":
+            fail.append(r.get("key"))
+    if fail:
+        lines.append("## ❌ Manifest Task Failures")
+        for k in fail:
+            lines.append(f"- {k}")
+        lines.append("")
+    else:
+        lines.append("## ✅ Manifest Tasks")
+        lines.append("- All tasks OK")
+        lines.append("")
+
+    # 2) History: if series_n==0 or ok_all==False
+    hsum = history.get("summary") or {}
+    if hsum.get("series_n", 0) == 0:
+        lines.append("## ⚠️ History")
+        lines.append("- No exports found for history.")
+        lines.append("")
+    elif not hsum.get("ok_all", True):
+        lines.append("## ❌ History")
+        lines.append("- Trend checks not all OK.")
+        lines.append("")
+
+    # 3) Delta: if ok == False
+    dsum = delta.get("summary") or {}
+    if dsum.get("has_previous") and not dsum.get("ok", True):
+        lines.append("## ❌ Delta")
+        lines.append(
+            f"- removed_nodes={dsum.get('removed_ids') or dsum.get('removed_nodes')}, "
+            f"removed_edges={dsum.get('removed_edges')}"
+        )
+        lines.append("")
+
+    # 4) ID stability: if ok == False or jaccard below threshold
+    isb = idstab.get("summary") or {}
+    if isb.get("has_previous") and not isb.get("ok", True):
+        lines.append("## ❌ ID Stability")
+        lines.append(
+            f"- jaccard={isb.get('jaccard')} added={isb.get('added_ids')} "
+            f"removed={isb.get('removed_ids')}"
+        )
+        lines.append("")
+
+    # 5) Referential integrity: extract counts from report result if present
+    ri = None
+    for r in report.get("results") or []:
+        if r.get("key") == "exports_ref_integrity_latest":
+            ri = r
+            break
+    if ri:
+        c = ri.get("counts", {})
+        if any(
+            [
+                c.get("missing_endpoints", 0) > 0,
+                c.get("self_loops", 0) > 0,
+                c.get("duplicate_node_ids", 0) > 0,
+                c.get("duplicate_edge_pairs", 0) > 0,
+            ]
+        ):
+            lines.append("## ⚠️ Referential Integrity (counts)")
+            lines.append(
+                f"- missing_endpoints={c.get('missing_endpoints',0)} "
+                f"self_loops={c.get('self_loops',0)} "
+                f"dup_node_ids={c.get('duplicate_node_ids',0)} "
+                f"dup_edge_pairs={c.get('duplicate_edge_pairs',0)}"
+            )
+            lines.append("")
+
+    if len(lines) <= 4:
+        lines.append("_No anomalies detected._")
+
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.anomalies] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.anomalies] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/build_index.py
+++ b/scripts/eval/build_index.py
@@ -16,6 +16,8 @@ def main() -> int:
         ("delta.md", "Delta (latest vs previous)"),
         ("provenance.md", "Provenance"),
         ("checksums.csv", "Checksums"),
+        ("anomalies.md", "Anomalies"),
+        ("run_log.jsonl", "Run Log"),
     ]
     lines = []
     lines.append("# Gemantria Eval — Artifacts Index")

--- a/scripts/eval/run_log.py
+++ b/scripts/eval/run_log.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import time
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVAL = ROOT / "share" / "eval"
+LOG = EVAL / "run_log.jsonl"
+
+
+def _load(p: pathlib.Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else None
+
+
+def main() -> int:
+    print("[eval.runlog] starting")
+    EVAL.mkdir(parents=True, exist_ok=True)
+    row = {
+        "ts_unix": int(time.time()),
+        "provenance": _load(EVAL / "provenance.json"),
+        "report": _load(EVAL / "report.json"),
+        "history": _load(EVAL / "history.json"),
+        "delta": _load(EVAL / "delta.json"),
+        "id_stability": _load(EVAL / "id_stability.json"),
+    }
+    with LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row, sort_keys=True) + "\n")
+    print(f"[eval.runlog] appended {LOG.relative_to(ROOT)}")
+    print("[eval.runlog] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds anomalies markdown, run-log JSONL, make targets, index enrichment. No CI/order changes.

## Summary by Sourcery

Add local-only anomalies aggregation and append-only run-log functionality to the evaluation workflow, updating scripts, Makefile targets, index generation, and documentation.

New Features:
- Add eval.anomalies target and script to consolidate evaluation anomalies into share/eval/anomalies.md
- Add eval.runlog target and script to append evaluation run snapshots to share/eval/run_log.jsonl

Enhancements:
- Include anomalies and run-log entries in the artifacts index
- Define CI variants for the new evaluation tasks

Build:
- Add Makefile PHONY entries and targets for anomalies and run-log

Documentation:
- Document the new anomalies and run-log tasks and outputs in PHASE8_EVAL.md