### PR TITLE
ops/eval: apply repair plan → repaired export + strict/dev policy delta (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,3 +315,26 @@ eval.profile.dev:
 # Build a non-destructive repair plan (JSON + MD)
 eval.repairplan:
 	@python3 scripts/eval/build_repair_plan.py
+
+.PHONY: repair.apply ci.repair.apply eval.policydiff ci.eval.policydiff eval.report.repaired ci.eval.report.repaired
+
+# Apply repair plan to produce a repaired export (adds stub nodes)
+repair.apply:
+	@python3 scripts/fix/apply_repair_plan.py
+
+ci.repair.apply:
+	@python3 scripts/fix/apply_repair_plan.py
+
+# Run manifest report against the repaired export
+eval.report.repaired:
+	@python3 scripts/eval/report_for_file.py exports/graph_repaired.json
+
+ci.eval.report.repaired:
+	@python3 scripts/eval/report_for_file.py exports/graph_repaired.json
+
+# Compare strict vs dev outcomes and write policy_diff.md
+eval.policydiff:
+	@python3 scripts/eval/policy_diff.py
+
+ci.eval.policydiff:
+	@python3 scripts/eval/policy_diff.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -206,3 +206,28 @@ Artifacts:
 
 * `share/eval/repair_plan.json` — proposed stub nodes to fix missing endpoints
 * `share/eval/repair_plan.md` — human-readable summary
+
+### Repaired export (local-only)
+Run:
+```bash
+make eval.repairplan
+make repair.apply
+make eval.report.repaired
+```
+
+Artifacts:
+
+* `exports/graph_repaired.json` and time-stamped `exports/graph_repaired_*.json`
+* `share/eval/report_for_graph_repaired.json` — manifest report applied to repaired file
+
+### Policy delta (local-only)
+
+Run:
+
+```bash
+make eval.policydiff
+```
+
+Artifact:
+
+* `share/eval/policy_diff.md` — pass/fail summary for strict vs dev

--- a/exports/graph_repaired.json
+++ b/exports/graph_repaired.json
@@ -1,0 +1,600 @@
+{
+  "edges": [
+    {
+      "rerank": 1.0,
+      "source": "48e1b80e-5a65-46a5-affb-8096d488a461",
+      "strength": 0.5008549258509712,
+      "target": "8d01e612-5d7e-4141-abf2-5a0170fadebc",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "strength": 0.5008549258509712,
+      "target": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "strength": 0.5008549258509712,
+      "target": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "strength": 0.5008549258509712,
+      "target": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "strength": 0.5008549258509712,
+      "target": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "strength": 0.5008549258509712,
+      "target": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "strength": 0.5008549258509712,
+      "target": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "2fc670dd-dc8a-4934-8cb5-8b687d320745",
+      "strength": 0.5008549258509712,
+      "target": "65238c25-daa3-47e7-8fe2-5e15fc9db154",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "a0132735-fa0a-49d8-8820-883e0cfa4eab",
+      "strength": 0.5008549258509712,
+      "target": "93193d79-f5ae-4157-b43e-58d0a0f6937b",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "68d24797-fc47-4ced-a9c7-7394de809aa0",
+      "strength": 0.5008549258509712,
+      "target": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "strength": 0.5008549258509712,
+      "target": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "strength": 0.5008549258509712,
+      "target": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "c16abc66-564f-470d-8743-f058544643bc",
+      "strength": 0.5008549258509712,
+      "target": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 0.5008549258509712,
+      "target": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "strength": 0.5008549258509712,
+      "target": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "yes": true
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "strength": 0.8714614994026108,
+      "target": "c872ae33-cb95-45dd-bae3-96d3a7774115",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "strength": 0.8614576125207303,
+      "target": "0382f0bf-c709-4697-809d-b7c171729973",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "strength": 0.8896367967559001,
+      "target": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "strength": 0.8722965525875251,
+      "target": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "strength": 0.8722965525875251,
+      "target": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "strength": 0.8663023323072763,
+      "target": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "strength": 0.8896367967559001,
+      "target": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "strength": 0.8663023323072763,
+      "target": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "yes": null
+    }
+  ],
+  "metadata": {
+    "cluster_count": 18,
+    "edge_count": 26,
+    "export_timestamp": "2025-10-23 17:59:42.882918-07:00",
+    "node_count": 28
+  },
+  "nodes": [
+    {
+      "betweenness": 0.0,
+      "cluster": 7,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "17db3202-47bb-4b41-a703-c1d3d8d24547",
+      "label": "17db3202-47bb-4b41-a703-c1d3d8d24547"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "186f30ee-6aea-430a-9532-4f818ff5b68c",
+      "label": "186f30ee-6aea-430a-9532-4f818ff5b68c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa",
+      "label": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3228ef61-5b6e-427b-965c-e728baa38f69",
+      "label": "3228ef61-5b6e-427b-965c-e728baa38f69"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 4,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1",
+      "label": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 0,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3de91147-5825-424a-bd8f-ac1acf75eae6",
+      "label": "3de91147-5825-424a-bd8f-ac1acf75eae6"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 11,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5",
+      "label": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 2,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4ac49ee6-6a07-4592-839a-c695cbb142b3",
+      "label": "4ac49ee6-6a07-4592-839a-c695cbb142b3"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "50f25e3e-bf0a-48dd-b119-971a19d204c4",
+      "label": "50f25e3e-bf0a-48dd-b119-971a19d204c4"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 1,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23",
+      "label": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "58b5f280-75f8-4043-a293-8fa1b272c014",
+      "label": "58b5f280-75f8-4043-a293-8fa1b272c014"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 6,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "5e75f102-d3e7-4336-8290-0e74ef9a316f",
+      "label": "5e75f102-d3e7-4336-8290-0e74ef9a316f"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "64747c10-4f52-4c7c-a0e3-00197212619c",
+      "label": "64747c10-4f52-4c7c-a0e3-00197212619c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 16,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "65be1afb-512f-436d-bf29-ba832ff02f30",
+      "label": "65be1afb-512f-436d-bf29-ba832ff02f30"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 13,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787",
+      "label": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 14,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "75da1201-1f9c-4da7-96a6-e048fd19f6e2",
+      "label": "75da1201-1f9c-4da7-96a6-e048fd19f6e2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 17,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "77598929-6118-45e9-a5ee-920f074f6e3d",
+      "label": "77598929-6118-45e9-a5ee-920f074f6e3d"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 15,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "7bae5d38-3cb0-4468-a4f8-0c57eb803388",
+      "label": "7bae5d38-3cb0-4468-a4f8-0c57eb803388"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "9343ede1-71ed-4e61-b6c6-c33f075cc787",
+      "label": "9343ede1-71ed-4e61-b6c6-c33f075cc787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 12,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a070ac83-1809-4852-8549-b6d54fb4f813",
+      "label": "a070ac83-1809-4852-8549-b6d54fb4f813"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 10,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a07b1323-35d6-4c16-ad56-7ab6f6566bad",
+      "label": "a07b1323-35d6-4c16-ad56-7ab6f6566bad"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 8,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a52d7d06-d277-481f-be72-4bfc35f16cc2",
+      "label": "a52d7d06-d277-481f-be72-4bfc35f16cc2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 5,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b",
+      "label": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "c97b3527-9281-4b00-8510-8caf954d20dc",
+      "label": "c97b3527-9281-4b00-8510-8caf954d20dc"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ca06a29b-502d-49a2-81a5-766dd28e8871",
+      "label": "ca06a29b-502d-49a2-81a5-766dd28e8871"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 9,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5",
+      "label": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ed13aed9-5c04-43f0-ae70-3a126724ab25",
+      "label": "ed13aed9-5c04-43f0-ae70-3a126724ab25"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 3,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ef695e45-f28a-4007-a89b-10c62c3743ed",
+      "label": "ef695e45-f28a-4007-a89b-10c62c3743ed"
+    },
+    {
+      "id": "0382f0bf-c709-4697-809d-b7c171729973",
+      "label": "[MISSING:0382f0bf-c709-4697-809d-b7c171729973] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "label": "[MISSING:03e5a98c-0ca6-4c37-86d3-1a6723146b3f] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "2fc670dd-dc8a-4934-8cb5-8b687d320745",
+      "label": "[MISSING:2fc670dd-dc8a-4934-8cb5-8b687d320745] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "label": "[MISSING:370140c5-cfcd-4084-bb5e-1bb6c1ed7c38] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "label": "[MISSING:3f115335-5ba1-4fac-b12c-62155fd4934a] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "label": "[MISSING:48b461e6-92ba-4100-87a1-b3796794fb9a] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "48e1b80e-5a65-46a5-affb-8096d488a461",
+      "label": "[MISSING:48e1b80e-5a65-46a5-affb-8096d488a461] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "label": "[MISSING:53137033-a0be-4bfe-9335-d826f34e4e00] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "65238c25-daa3-47e7-8fe2-5e15fc9db154",
+      "label": "[MISSING:65238c25-daa3-47e7-8fe2-5e15fc9db154] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "label": "[MISSING:67472518-0fca-4fd9-8780-bd97beafcdc9] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "68d24797-fc47-4ced-a9c7-7394de809aa0",
+      "label": "[MISSING:68d24797-fc47-4ced-a9c7-7394de809aa0] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "label": "[MISSING:8be83aa2-cb97-4411-babd-6813c0115c88] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8d01e612-5d7e-4141-abf2-5a0170fadebc",
+      "label": "[MISSING:8d01e612-5d7e-4141-abf2-5a0170fadebc] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "label": "[MISSING:8f26a22e-7e15-48e7-82b6-76cd1011054f] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "93193d79-f5ae-4157-b43e-58d0a0f6937b",
+      "label": "[MISSING:93193d79-f5ae-4157-b43e-58d0a0f6937b] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "a0132735-fa0a-49d8-8820-883e0cfa4eab",
+      "label": "[MISSING:a0132735-fa0a-49d8-8820-883e0cfa4eab] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "label": "[MISSING:a1bb09c4-4f27-4941-b2e9-6b2d387673ae] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "label": "[MISSING:b1c17ab3-33d1-4c20-8fda-437da9306755] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "label": "[MISSING:bc8c30ff-64c9-4af8-a139-78b8635e3718] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c16abc66-564f-470d-8743-f058544643bc",
+      "label": "[MISSING:c16abc66-564f-470d-8743-f058544643bc] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "label": "[MISSING:c567b8f1-a14e-48c7-9676-4b31a1ee0156] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "label": "[MISSING:c63d84be-e5d7-4efc-8461-6ee716c01b36] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c872ae33-cb95-45dd-bae3-96d3a7774115",
+      "label": "[MISSING:c872ae33-cb95-45dd-bae3-96d3a7774115] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "label": "[MISSING:d2b1cc0c-076c-441c-bf52-5a36ac362c4d] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "label": "[MISSING:e24f91fb-34e6-455d-9f5f-76a5600c81d6] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "label": "[MISSING:e95d1521-379a-44a9-aaf3-a11c48bfb570] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    }
+  ]
+}

--- a/exports/graph_repaired_20251025205829.json
+++ b/exports/graph_repaired_20251025205829.json
@@ -1,0 +1,600 @@
+{
+  "edges": [
+    {
+      "rerank": 1.0,
+      "source": "48e1b80e-5a65-46a5-affb-8096d488a461",
+      "strength": 0.5008549258509712,
+      "target": "8d01e612-5d7e-4141-abf2-5a0170fadebc",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "strength": 0.5008549258509712,
+      "target": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "strength": 0.5008549258509712,
+      "target": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "strength": 0.5008549258509712,
+      "target": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "strength": 0.5008549258509712,
+      "target": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "strength": 0.5008549258509712,
+      "target": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "strength": 0.5008549258509712,
+      "target": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "2fc670dd-dc8a-4934-8cb5-8b687d320745",
+      "strength": 0.5008549258509712,
+      "target": "65238c25-daa3-47e7-8fe2-5e15fc9db154",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "a0132735-fa0a-49d8-8820-883e0cfa4eab",
+      "strength": 0.5008549258509712,
+      "target": "93193d79-f5ae-4157-b43e-58d0a0f6937b",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "68d24797-fc47-4ced-a9c7-7394de809aa0",
+      "strength": 0.5008549258509712,
+      "target": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "strength": 0.5008549258509712,
+      "target": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "strength": 0.5008549258509712,
+      "target": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "c16abc66-564f-470d-8743-f058544643bc",
+      "strength": 0.5008549258509712,
+      "target": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 0.5008549258509712,
+      "target": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "yes": true
+    },
+    {
+      "rerank": 1.0,
+      "source": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "strength": 0.5008549258509712,
+      "target": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "yes": true
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "strength": 1.0,
+      "target": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "strength": 0.8714614994026108,
+      "target": "c872ae33-cb95-45dd-bae3-96d3a7774115",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "strength": 0.8614576125207303,
+      "target": "0382f0bf-c709-4697-809d-b7c171729973",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "strength": 0.8896367967559001,
+      "target": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "strength": 0.8722965525875251,
+      "target": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "strength": 0.8722965525875251,
+      "target": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "yes": null
+    },
+    {
+      "rerank": 1.0,
+      "source": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "strength": 0.8663023323072763,
+      "target": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "strength": 0.8896367967559001,
+      "target": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "yes": null
+    },
+    {
+      "rerank": null,
+      "source": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "strength": 0.8663023323072763,
+      "target": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "yes": null
+    }
+  ],
+  "metadata": {
+    "cluster_count": 18,
+    "edge_count": 26,
+    "export_timestamp": "2025-10-23 17:59:42.882918-07:00",
+    "node_count": 28
+  },
+  "nodes": [
+    {
+      "betweenness": 0.0,
+      "cluster": 7,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "17db3202-47bb-4b41-a703-c1d3d8d24547",
+      "label": "17db3202-47bb-4b41-a703-c1d3d8d24547"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "186f30ee-6aea-430a-9532-4f818ff5b68c",
+      "label": "186f30ee-6aea-430a-9532-4f818ff5b68c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa",
+      "label": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3228ef61-5b6e-427b-965c-e728baa38f69",
+      "label": "3228ef61-5b6e-427b-965c-e728baa38f69"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 4,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1",
+      "label": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 0,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3de91147-5825-424a-bd8f-ac1acf75eae6",
+      "label": "3de91147-5825-424a-bd8f-ac1acf75eae6"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 11,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5",
+      "label": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 2,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4ac49ee6-6a07-4592-839a-c695cbb142b3",
+      "label": "4ac49ee6-6a07-4592-839a-c695cbb142b3"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "50f25e3e-bf0a-48dd-b119-971a19d204c4",
+      "label": "50f25e3e-bf0a-48dd-b119-971a19d204c4"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 1,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23",
+      "label": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "58b5f280-75f8-4043-a293-8fa1b272c014",
+      "label": "58b5f280-75f8-4043-a293-8fa1b272c014"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 6,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "5e75f102-d3e7-4336-8290-0e74ef9a316f",
+      "label": "5e75f102-d3e7-4336-8290-0e74ef9a316f"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "64747c10-4f52-4c7c-a0e3-00197212619c",
+      "label": "64747c10-4f52-4c7c-a0e3-00197212619c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 16,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "65be1afb-512f-436d-bf29-ba832ff02f30",
+      "label": "65be1afb-512f-436d-bf29-ba832ff02f30"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 13,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787",
+      "label": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 14,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "75da1201-1f9c-4da7-96a6-e048fd19f6e2",
+      "label": "75da1201-1f9c-4da7-96a6-e048fd19f6e2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 17,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "77598929-6118-45e9-a5ee-920f074f6e3d",
+      "label": "77598929-6118-45e9-a5ee-920f074f6e3d"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 15,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "7bae5d38-3cb0-4468-a4f8-0c57eb803388",
+      "label": "7bae5d38-3cb0-4468-a4f8-0c57eb803388"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "9343ede1-71ed-4e61-b6c6-c33f075cc787",
+      "label": "9343ede1-71ed-4e61-b6c6-c33f075cc787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 12,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a070ac83-1809-4852-8549-b6d54fb4f813",
+      "label": "a070ac83-1809-4852-8549-b6d54fb4f813"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 10,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a07b1323-35d6-4c16-ad56-7ab6f6566bad",
+      "label": "a07b1323-35d6-4c16-ad56-7ab6f6566bad"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 8,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a52d7d06-d277-481f-be72-4bfc35f16cc2",
+      "label": "a52d7d06-d277-481f-be72-4bfc35f16cc2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 5,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b",
+      "label": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "c97b3527-9281-4b00-8510-8caf954d20dc",
+      "label": "c97b3527-9281-4b00-8510-8caf954d20dc"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ca06a29b-502d-49a2-81a5-766dd28e8871",
+      "label": "ca06a29b-502d-49a2-81a5-766dd28e8871"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 9,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5",
+      "label": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ed13aed9-5c04-43f0-ae70-3a126724ab25",
+      "label": "ed13aed9-5c04-43f0-ae70-3a126724ab25"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 3,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ef695e45-f28a-4007-a89b-10c62c3743ed",
+      "label": "ef695e45-f28a-4007-a89b-10c62c3743ed"
+    },
+    {
+      "id": "0382f0bf-c709-4697-809d-b7c171729973",
+      "label": "[MISSING:0382f0bf-c709-4697-809d-b7c171729973] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "03e5a98c-0ca6-4c37-86d3-1a6723146b3f",
+      "label": "[MISSING:03e5a98c-0ca6-4c37-86d3-1a6723146b3f] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "2fc670dd-dc8a-4934-8cb5-8b687d320745",
+      "label": "[MISSING:2fc670dd-dc8a-4934-8cb5-8b687d320745] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "370140c5-cfcd-4084-bb5e-1bb6c1ed7c38",
+      "label": "[MISSING:370140c5-cfcd-4084-bb5e-1bb6c1ed7c38] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "3f115335-5ba1-4fac-b12c-62155fd4934a",
+      "label": "[MISSING:3f115335-5ba1-4fac-b12c-62155fd4934a] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "48b461e6-92ba-4100-87a1-b3796794fb9a",
+      "label": "[MISSING:48b461e6-92ba-4100-87a1-b3796794fb9a] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "48e1b80e-5a65-46a5-affb-8096d488a461",
+      "label": "[MISSING:48e1b80e-5a65-46a5-affb-8096d488a461] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "53137033-a0be-4bfe-9335-d826f34e4e00",
+      "label": "[MISSING:53137033-a0be-4bfe-9335-d826f34e4e00] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "65238c25-daa3-47e7-8fe2-5e15fc9db154",
+      "label": "[MISSING:65238c25-daa3-47e7-8fe2-5e15fc9db154] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "67472518-0fca-4fd9-8780-bd97beafcdc9",
+      "label": "[MISSING:67472518-0fca-4fd9-8780-bd97beafcdc9] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "68d24797-fc47-4ced-a9c7-7394de809aa0",
+      "label": "[MISSING:68d24797-fc47-4ced-a9c7-7394de809aa0] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8be83aa2-cb97-4411-babd-6813c0115c88",
+      "label": "[MISSING:8be83aa2-cb97-4411-babd-6813c0115c88] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8d01e612-5d7e-4141-abf2-5a0170fadebc",
+      "label": "[MISSING:8d01e612-5d7e-4141-abf2-5a0170fadebc] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "8f26a22e-7e15-48e7-82b6-76cd1011054f",
+      "label": "[MISSING:8f26a22e-7e15-48e7-82b6-76cd1011054f] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "93193d79-f5ae-4157-b43e-58d0a0f6937b",
+      "label": "[MISSING:93193d79-f5ae-4157-b43e-58d0a0f6937b] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "a0132735-fa0a-49d8-8820-883e0cfa4eab",
+      "label": "[MISSING:a0132735-fa0a-49d8-8820-883e0cfa4eab] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "a1bb09c4-4f27-4941-b2e9-6b2d387673ae",
+      "label": "[MISSING:a1bb09c4-4f27-4941-b2e9-6b2d387673ae] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "b1c17ab3-33d1-4c20-8fda-437da9306755",
+      "label": "[MISSING:b1c17ab3-33d1-4c20-8fda-437da9306755] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "bc8c30ff-64c9-4af8-a139-78b8635e3718",
+      "label": "[MISSING:bc8c30ff-64c9-4af8-a139-78b8635e3718] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c16abc66-564f-470d-8743-f058544643bc",
+      "label": "[MISSING:c16abc66-564f-470d-8743-f058544643bc] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c567b8f1-a14e-48c7-9676-4b31a1ee0156",
+      "label": "[MISSING:c567b8f1-a14e-48c7-9676-4b31a1ee0156] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c63d84be-e5d7-4efc-8461-6ee716c01b36",
+      "label": "[MISSING:c63d84be-e5d7-4efc-8461-6ee716c01b36] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "c872ae33-cb95-45dd-bae3-96d3a7774115",
+      "label": "[MISSING:c872ae33-cb95-45dd-bae3-96d3a7774115] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "d2b1cc0c-076c-441c-bf52-5a36ac362c4d",
+      "label": "[MISSING:d2b1cc0c-076c-441c-bf52-5a36ac362c4d] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "e24f91fb-34e6-455d-9f5f-76a5600c81d6",
+      "label": "[MISSING:e24f91fb-34e6-455d-9f5f-76a5600c81d6] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    },
+    {
+      "id": "e95d1521-379a-44a9-aaf3-a11c48bfb570",
+      "label": "[MISSING:e95d1521-379a-44a9-aaf3-a11c48bfb570] (stub)",
+      "meta": {
+        "proposed_stub": true
+      }
+    }
+  ]
+}

--- a/exports/graph_sanitized_20251025122752.json
+++ b/exports/graph_sanitized_20251025122752.json
@@ -1,0 +1,235 @@
+{
+  "edges": [],
+  "metadata": {
+    "cluster_count": 18,
+    "edge_count": 26,
+    "export_timestamp": "2025-10-23 17:59:42.882918-07:00",
+    "node_count": 28
+  },
+  "nodes": [
+    {
+      "betweenness": 0.0,
+      "cluster": 7,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "17db3202-47bb-4b41-a703-c1d3d8d24547",
+      "label": "17db3202-47bb-4b41-a703-c1d3d8d24547"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "186f30ee-6aea-430a-9532-4f818ff5b68c",
+      "label": "186f30ee-6aea-430a-9532-4f818ff5b68c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa",
+      "label": "2fac55d7-fdee-4e00-bf4c-d4ab617474fa"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3228ef61-5b6e-427b-965c-e728baa38f69",
+      "label": "3228ef61-5b6e-427b-965c-e728baa38f69"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 4,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1",
+      "label": "3c4cdaf5-b118-43dd-8ffb-7a3fba87e9a1"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 0,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "3de91147-5825-424a-bd8f-ac1acf75eae6",
+      "label": "3de91147-5825-424a-bd8f-ac1acf75eae6"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 11,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5",
+      "label": "4233fe0e-43c6-434b-9e8b-506d18dcc7e5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 2,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "4ac49ee6-6a07-4592-839a-c695cbb142b3",
+      "label": "4ac49ee6-6a07-4592-839a-c695cbb142b3"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "50f25e3e-bf0a-48dd-b119-971a19d204c4",
+      "label": "50f25e3e-bf0a-48dd-b119-971a19d204c4"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 1,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23",
+      "label": "51f6cef6-fba7-4d5c-ac07-decbf7e32c23"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "58b5f280-75f8-4043-a293-8fa1b272c014",
+      "label": "58b5f280-75f8-4043-a293-8fa1b272c014"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 6,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "5e75f102-d3e7-4336-8290-0e74ef9a316f",
+      "label": "5e75f102-d3e7-4336-8290-0e74ef9a316f"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "64747c10-4f52-4c7c-a0e3-00197212619c",
+      "label": "64747c10-4f52-4c7c-a0e3-00197212619c"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 16,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "65be1afb-512f-436d-bf29-ba832ff02f30",
+      "label": "65be1afb-512f-436d-bf29-ba832ff02f30"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 13,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787",
+      "label": "6f58d7af-b7e5-4b2a-8e6b-090ca4ea5787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 14,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "75da1201-1f9c-4da7-96a6-e048fd19f6e2",
+      "label": "75da1201-1f9c-4da7-96a6-e048fd19f6e2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 17,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "77598929-6118-45e9-a5ee-920f074f6e3d",
+      "label": "77598929-6118-45e9-a5ee-920f074f6e3d"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 15,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "7bae5d38-3cb0-4468-a4f8-0c57eb803388",
+      "label": "7bae5d38-3cb0-4468-a4f8-0c57eb803388"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "9343ede1-71ed-4e61-b6c6-c33f075cc787",
+      "label": "9343ede1-71ed-4e61-b6c6-c33f075cc787"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 12,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a070ac83-1809-4852-8549-b6d54fb4f813",
+      "label": "a070ac83-1809-4852-8549-b6d54fb4f813"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 10,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a07b1323-35d6-4c16-ad56-7ab6f6566bad",
+      "label": "a07b1323-35d6-4c16-ad56-7ab6f6566bad"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 8,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "a52d7d06-d277-481f-be72-4bfc35f16cc2",
+      "label": "a52d7d06-d277-481f-be72-4bfc35f16cc2"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 5,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b",
+      "label": "b5d0c295-1d9a-4f0d-b8a4-14d69de0b90b"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "c97b3527-9281-4b00-8510-8caf954d20dc",
+      "label": "c97b3527-9281-4b00-8510-8caf954d20dc"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ca06a29b-502d-49a2-81a5-766dd28e8871",
+      "label": "ca06a29b-502d-49a2-81a5-766dd28e8871"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 9,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5",
+      "label": "dda93bbd-715c-4cd1-9ee8-55dd9128cdc5"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": null,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ed13aed9-5c04-43f0-ae70-3a126724ab25",
+      "label": "ed13aed9-5c04-43f0-ae70-3a126724ab25"
+    },
+    {
+      "betweenness": 0.0,
+      "cluster": 3,
+      "degree": 0.0,
+      "eigenvector": 0.0,
+      "id": "ef695e45-f28a-4007-a89b-10c62c3743ed",
+      "label": "ef695e45-f28a-4007-a89b-10c62c3743ed"
+    }
+  ]
+}

--- a/scripts/eval/policy_diff.py
+++ b/scripts/eval/policy_diff.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUT = ROOT / "share" / "eval" / "policy_diff.md"
+
+
+def _run(cmd: list[str]) -> tuple[int, str, str]:
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    return r.returncode, r.stdout, r.stderr
+
+
+def _summary(path: pathlib.Path) -> tuple[int, int]:
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        s = doc.get("summary", {})
+        return int(s.get("ok_count", 0)), int(s.get("fail_count", 0))
+    except Exception:
+        return 0, 0
+
+
+def main() -> int:
+    print("[eval.policydiff] starting")
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+
+    # strict
+    code, so, se = _run(["make", "eval.profile.strict"])
+    ok_strict, fail_strict = _summary(ROOT / "share" / "eval" / "report.json")
+
+    # dev
+    code, so, se = _run(["make", "eval.profile.dev"])
+    ok_dev, fail_dev = _summary(ROOT / "share" / "eval" / "report.json")
+
+    lines = []
+    lines.append("# Gemantria Policy Delta")
+    lines.append("")
+    lines.append(f"*strict:* ok={ok_strict} fail={fail_strict}")
+    lines.append(f"*dev:*    ok={ok_dev} fail={fail_dev}")
+    lines.append("")
+    if fail_strict > fail_dev:
+        lines.append(
+            "**Observation:** Dev profile masks some failures present under strict."
+        )
+    elif fail_strict == fail_dev:
+        lines.append("**Observation:** Profiles produce identical pass/fail counts.")
+    else:
+        lines.append(
+            "**Observation:** Dev profile surfaced more failures (unexpected)."
+        )
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.policydiff] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.policydiff] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fix/apply_repair_plan.py
+++ b/scripts/fix/apply_repair_plan.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+import time
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EXPORTS = ROOT / "exports"
+LATEST = EXPORTS / "graph_latest.json"
+PLAN_J = ROOT / "share" / "eval" / "repair_plan.json"
+
+
+def _load_json(p: pathlib.Path) -> Any:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _node_ids(nodes: list[dict[str, Any]]) -> set[Any]:
+    out = set()
+    for n in nodes:
+        if isinstance(n, dict) and "id" in n:
+            out.add(n["id"])
+    return out
+
+
+def main() -> int:
+    print("[repair.apply] starting")
+    if not LATEST.exists():
+        print("[repair.apply] FAIL no exports/graph_latest.json")
+        return 2
+    if not PLAN_J.exists():
+        print(
+            "[repair.apply] FAIL no share/eval/repair_plan.json (run make eval.repairplan)"
+        )
+        return 2
+
+    base = _load_json(LATEST)
+    plan = _load_json(PLAN_J)
+    nodes = list(base.get("nodes", []) or [])
+
+    have = _node_ids(nodes)
+    stubs = plan.get("proposed_stubs", []) or []
+    added = []
+    for s in stubs:
+        sid = s.get("id")
+        if sid not in have:
+            nodes.append(s)
+            added.append(sid)
+
+    out = dict(base)
+    out["nodes"] = nodes
+    ts = time.strftime("%Y%m%d%H%M%S")
+    out_path = EXPORTS / f"graph_repaired_{ts}.json"
+    (EXPORTS / "graph_repaired.json").write_text(
+        json.dumps(out, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    out_path.write_text(json.dumps(out, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(f"[repair.apply] added_stub_nodes={len(added)}")
+    print(f"[repair.apply] wrote {out_path.relative_to(ROOT)}")
+    print(f"[repair.apply] wrote {(EXPORTS/'graph_repaired.json').relative_to(ROOT)}")
+    print("[repair.apply] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds:

- **Repair apply**: `scripts/fix/apply_repair_plan.py` + `make repair.apply` to produce `exports/graph_repaired.json` from `share/eval/repair_plan.json` (adds stub nodes; non-destructive).
- **Policy delta**: `scripts/eval/policy_diff.py` + `make eval.policydiff` to compare strict vs dev outcomes and write `share/eval/policy_diff.md`.
- **Evaluation for repaired export**: `make eval.report.repaired` to run manifest against repaired file.
- **Docs**: `docs/PHASE8_EVAL.md` sections for repaired export + policy delta.

Governance: STRICT. No CI/order drift. Local-only utilities.

Acceptance (as executed locally):
- `make repair.apply` → added 26 stub nodes; wrote `exports/graph_repaired.json`.
- `make eval.report.repaired` → referential integrity `OK`.
- `make eval.policydiff` → strict: 9 OK / 1 FAIL; dev: 10 OK / 0 FAIL.
- `make ops.verify` → `[ops.verify] OK`.

## Summary by Sourcery

Provide local-only utilities to apply repair plans and generate repaired graph exports, compare strict vs dev evaluation profiles, integrate new CLI targets into the Makefile, and document the workflows in PHASE8_EVAL.md

New Features:
- Add apply_repair_plan.py script and repair.apply Makefile target to generate a repaired graph export with stub nodes
- Add policy_diff.py script and eval.policydiff Makefile target to compare strict vs dev evaluation outcomes
- Add eval.report.repaired Makefile target to run manifest reports against the repaired export

Build:
- Add phony Makefile targets for repair.apply, eval.policydiff, eval.report.repaired and their CI variants

Documentation:
- Update PHASE8_EVAL.md with instructions and artifacts for repaired export and policy delta workflows