### PR TITLE
ops/eval: snapshot + HTML dashboard + bundle + strict preflight gate (local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,3 +338,33 @@ eval.policydiff:
 
 ci.eval.policydiff:
 	@python3 scripts/eval/policy_diff.py
+
+.PHONY: eval.snapshot ci.eval.snapshot eval.html ci.eval.html eval.bundle ci.eval.bundle eval.gate.strict ci.eval.gate.strict
+
+# Create config snapshots (manifest, thresholds, provenance)
+eval.snapshot:
+	@python3 scripts/eval/build_snapshot.py
+
+ci.eval.snapshot:
+	@python3 scripts/eval/build_snapshot.py
+
+# Generate HTML dashboard with artifact links and badges
+eval.html:
+	@python3 scripts/eval/build_html_index.py
+
+ci.eval.html:
+	@python3 scripts/eval/build_html_index.py
+
+# Create distributable bundle (tar.gz) with all artifacts
+eval.bundle:
+	@python3 scripts/eval/build_bundle.py
+
+ci.eval.bundle:
+	@python3 scripts/eval/build_bundle.py
+
+# Strict profile gate - fails if any failures detected (unless ALLOW_FAIL=1)
+eval.gate.strict:
+	@python3 scripts/eval/gate_strict.py
+
+ci.eval.gate.strict:
+	@python3 scripts/eval/gate_strict.py

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -231,3 +231,58 @@ make eval.policydiff
 Artifact:
 
 * `share/eval/policy_diff.md` — pass/fail summary for strict vs dev
+
+### Config snapshots (local-only)
+
+Create frozen copies of configuration used for evaluation:
+
+```bash
+make eval.snapshot
+```
+
+Artifacts:
+
+* `share/eval/snapshot/manifest.snapshot.yml` — exact manifest used
+* `share/eval/snapshot/thresholds.snapshot.yml` — resolved thresholds
+* `share/eval/snapshot/provenance.snapshot.json` — git SHA, timestamp, tool versions
+
+### HTML dashboard (local-only)
+
+Generate browsable HTML dashboard with artifact links and pass/fail badges:
+
+```bash
+make eval.html
+```
+
+Artifact:
+
+* `share/eval/index.html` — lightweight dashboard linking to all artifacts with status badges
+
+### Bundle for handoff (local-only)
+
+Create distributable tar.gz bundle with all evaluation artifacts:
+
+```bash
+make eval.bundle
+```
+
+Artifact:
+
+* `share/eval/bundles/eval_bundle_<ts>.tar.gz` — includes:
+  * `share/eval/*` (all artifacts)
+  * `exports/graph_{latest,sanitized,repaired}.json` (if present)
+  * `eval/manifest.yml`, `eval/thresholds.yml`
+  * `share/eval/snapshot/*` (snapshot files)
+
+### Strict preflight gate (local-only)
+
+Quality gate that enforces zero failures under strict profile:
+
+```bash
+make eval.gate.strict
+```
+
+Returns:
+* `0` (success) — no failures detected
+* `1` (failure) — failures detected in strict profile
+* Override with `ALLOW_FAIL=1` environment variable

--- a/scripts/eval/build_bundle.py
+++ b/scripts/eval/build_bundle.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import pathlib
+import tarfile
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BUNDLES_DIR = ROOT / "share" / "eval" / "bundles"
+EVAL_DIR = ROOT / "share" / "eval"
+EXPORTS_DIR = ROOT / "exports"
+EVAL_CONFIG_DIR = ROOT / "eval"
+
+
+def main() -> int:
+    print("[eval.bundle] starting")
+
+    BUNDLES_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Generate timestamp
+    ts = time.strftime("%Y%m%d%H%M%S")
+    bundle_name = f"eval_bundle_{ts}.tar.gz"
+    bundle_path = BUNDLES_DIR / bundle_name
+
+    # Files to include
+    files_to_bundle = []
+
+    # Add share/eval/* artifacts
+    if EVAL_DIR.exists():
+        for item in EVAL_DIR.glob("*"):
+            if item.is_file():
+                files_to_bundle.append((item, f"share/eval/{item.name}"))
+
+    # Add exports (if present)
+    export_files = ["graph_latest.json", "graph_sanitized.json", "graph_repaired.json"]
+    for export_file in export_files:
+        export_path = EXPORTS_DIR / export_file
+        if export_path.exists():
+            files_to_bundle.append((export_path, f"exports/{export_file}"))
+
+    # Add eval config files
+    config_files = ["manifest.yml", "thresholds.yml"]
+    for config_file in config_files:
+        config_path = EVAL_CONFIG_DIR / config_file
+        if config_path.exists():
+            files_to_bundle.append((config_path, f"eval/{config_file}"))
+
+    # Add snapshot files (if present)
+    snapshot_dir = EVAL_DIR / "snapshot"
+    if snapshot_dir.exists():
+        for item in snapshot_dir.glob("*"):
+            if item.is_file():
+                files_to_bundle.append((item, f"share/eval/snapshot/{item.name}"))
+
+    # Create the tar.gz bundle
+    with tarfile.open(bundle_path, "w:gz") as tar:
+        for src_path, arc_name in files_to_bundle:
+            tar.add(src_path, arcname=arc_name)
+
+    print(f"[eval.bundle] created {bundle_path.relative_to(ROOT)}")
+    print(f"[eval.bundle] included {len(files_to_bundle)} files")
+    print("[eval.bundle] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/build_html_index.py
+++ b/scripts/eval/build_html_index.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+OUTDIR = ROOT / "share" / "eval"
+HTML_OUT = OUTDIR / "index.html"
+REPORT_JSON = OUTDIR / "report.json"
+
+
+def _status_badge(status: str) -> str:
+    if status == "OK":
+        return '<span style="background-color: #28a745; color: white; padding: 2px 8px; border-radius: 4px; font-size: 12px;">PASS</span>'
+    elif status == "FAIL":
+        return '<span style="background-color: #dc3545; color: white; padding: 2px 8px; border-radius: 4px; font-size: 12px;">FAIL</span>'
+    else:
+        return '<span style="background-color: #ffc107; color: black; padding: 2px 8px; border-radius: 4px; font-size: 12px;">WARN</span>'
+
+
+def _load_report() -> dict[str, any]:
+    if REPORT_JSON.exists():
+        return json.loads(REPORT_JSON.read_text(encoding="utf-8"))
+    return {"summary": {"ok_count": 0, "fail_count": 0}, "results": []}
+
+
+def main() -> int:
+    print("[eval.html] starting")
+
+    report = _load_report()
+    summary = report.get("summary", {})
+
+    html = []
+    html.append("<!DOCTYPE html>")
+    html.append("<html lang='en'>")
+    html.append("<head>")
+    html.append("    <meta charset='UTF-8'>")
+    html.append(
+        "    <meta name='viewport' content='width=device-width, initial-scale=1.0'>"
+    )
+    html.append("    <title>Gemantria Phase-8 Eval Dashboard</title>")
+    html.append("    <style>")
+    html.append(
+        "        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background-color: #f8f9fa; }"
+    )
+    html.append(
+        "        .container { max-width: 1200px; margin: 0 auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }"
+    )
+    html.append(
+        "        h1 { color: #333; border-bottom: 2px solid #007acc; padding-bottom: 10px; }"
+    )
+    html.append(
+        "        .summary { background: #f1f8ff; padding: 15px; border-radius: 6px; margin: 20px 0; }"
+    )
+    html.append("        .summary strong { color: #007acc; }")
+    html.append(
+        "        .artifacts { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 15px; margin: 20px 0; }"
+    )
+    html.append(
+        "        .artifact { border: 1px solid #e1e4e8; border-radius: 6px; padding: 15px; background: #fafbfc; }"
+    )
+    html.append("        .artifact h3 { margin: 0 0 10px 0; color: #333; }")
+    html.append("        .artifact a { color: #0366d6; text-decoration: none; }")
+    html.append("        .artifact a:hover { text-decoration: underline; }")
+    html.append("        .badge { margin-left: 10px; }")
+    html.append(
+        "        .footer { margin-top: 30px; padding-top: 20px; border-top: 1px solid #e1e4e8; color: #586069; font-size: 14px; }"
+    )
+    html.append("    </style>")
+    html.append("</head>")
+    html.append("<body>")
+    html.append("    <div class='container'>")
+    html.append("        <h1>🔍 Gemantria Phase-8 Evaluation Dashboard</h1>")
+    html.append("")
+    html.append("        <div class='summary'>")
+    html.append(
+        f"            <strong>Overall Status:</strong> {summary.get('ok_count', 0)} PASS, {summary.get('fail_count', 0)} FAIL"
+    )
+    html.append("        </div>")
+    html.append("")
+    html.append("        <div class='artifacts'>")
+
+    # Core reports
+    artifacts = [
+        (
+            "report.md",
+            "Core Evaluation Report",
+            "Primary evaluation results with pass/fail status for all tasks",
+        ),
+        ("report.json", "Report JSON", "Machine-readable evaluation results"),
+        ("history.md", "Temporal History", "Historical trends across export versions"),
+        ("history.json", "History JSON", "Machine-readable historical data"),
+        ("delta.md", "Per-Run Delta", "Changes between consecutive evaluations"),
+        ("delta.json", "Delta JSON", "Machine-readable delta analysis"),
+        ("anomalies.md", "Anomalies Summary", "Consolidated red flags and issues"),
+        (
+            "policy_diff.md",
+            "Policy Delta",
+            "Comparison of strict vs dev profile outcomes",
+        ),
+        ("provenance.md", "Provenance", "Git SHA, versions, and metadata"),
+        ("provenance.json", "Provenance JSON", "Machine-readable provenance data"),
+        ("checksums.csv", "File Checksums", "SHA256 hashes for all artifacts"),
+        ("run_log.jsonl", "Run Log", "Append-only execution history"),
+    ]
+
+    # Add artifacts with status badges where available
+    for filename, title, description in artifacts:
+        status = ""
+        if filename == "report.md":
+            status = "OK" if summary.get("fail_count", 0) == 0 else "FAIL"
+
+        badge = _status_badge(status) if status else ""
+        html.append("            <div class='artifact'>")
+        html.append(f"                <h3><a href='{filename}'>{title}</a>{badge}</h3>")
+        html.append(f"                <p>{description}</p>")
+        html.append("            </div>")
+
+    html.append("        </div>")
+    html.append("")
+    html.append("        <div class='footer'>")
+    html.append(
+        "            <p>Generated by Phase-8 evaluation system. Use <code>make eval.html</code> to regenerate.</p>"
+    )
+    html.append("        </div>")
+    html.append("    </div>")
+    html.append("</body>")
+    html.append("</html>")
+
+    HTML_OUT.write_text("\n".join(html), encoding="utf-8")
+
+    print(f"[eval.html] wrote {HTML_OUT.relative_to(ROOT)}")
+    print("[eval.html] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/build_snapshot.py
+++ b/scripts/eval/build_snapshot.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import pathlib
+import subprocess
+import time
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SNAPSHOT_DIR = ROOT / "share" / "eval" / "snapshot"
+MANIFEST = ROOT / "eval" / "manifest.yml"
+THRESHOLDS = ROOT / "eval" / "thresholds.yml"
+
+
+def _git(cmd: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(["git"] + cmd, cwd=ROOT).decode("utf-8").strip()
+    except Exception:
+        return None
+
+
+def _load_yaml(path: pathlib.Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def main() -> int:
+    print("[eval.snapshot] starting")
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Load source files
+    if not MANIFEST.exists():
+        print("[eval.snapshot] FAIL no eval/manifest.yml")
+        return 2
+    if not THRESHOLDS.exists():
+        print("[eval.snapshot] FAIL no eval/thresholds.yml")
+        return 2
+
+    manifest_data = _load_yaml(MANIFEST)
+    thresholds_data = _load_yaml(THRESHOLDS)
+
+    # Write snapshot files
+    manifest_snapshot = SNAPSHOT_DIR / "manifest.snapshot.yml"
+    thresholds_snapshot = SNAPSHOT_DIR / "thresholds.snapshot.yml"
+
+    with manifest_snapshot.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(manifest_data, f, default_flow_style=False, sort_keys=False)
+    with thresholds_snapshot.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(thresholds_data, f, default_flow_style=False, sort_keys=False)
+
+    # Create provenance snapshot
+    provenance = {
+        "git_head": _git(["rev-parse", "HEAD"]),
+        "git_branch": _git(["rev-parse", "--abbrev-ref", "HEAD"]),
+        "timestamp_unix": int(time.time()),
+        "timestamp_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "python_version": f"{__import__('sys').version_info.major}.{__import__('sys').version_info.minor}",
+        "manifest_version": manifest_data.get("version"),
+        "thresholds_version": thresholds_data.get("version"),
+    }
+
+    provenance_snapshot = SNAPSHOT_DIR / "provenance.snapshot.json"
+    import json
+
+    provenance_snapshot.write_text(
+        json.dumps(provenance, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    print(f"[eval.snapshot] wrote {manifest_snapshot.relative_to(ROOT)}")
+    print(f"[eval.snapshot] wrote {thresholds_snapshot.relative_to(ROOT)}")
+    print(f"[eval.snapshot] wrote {provenance_snapshot.relative_to(ROOT)}")
+    print("[eval.snapshot] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/gate_strict.py
+++ b/scripts/eval/gate_strict.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "share" / "eval" / "report.json"
+
+
+def main() -> int:
+    print("[eval.gate.strict] starting")
+
+    # Run strict profile evaluation directly (ignore make return code)
+    subprocess.run(
+        ["python3", "scripts/eval/run_with_profile.py", "strict"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    # Check if report was created (evaluation might succeed even with failures)
+    if not REPORT_JSON.exists():
+        print("[eval.gate.strict] FAIL: no report.json found after strict evaluation")
+        return 2
+
+    report = json.loads(REPORT_JSON.read_text(encoding="utf-8"))
+    summary = report.get("summary", {})
+    fail_count = summary.get("fail_count", 0)
+
+    if fail_count > 0:
+        allow_fail = os.getenv("ALLOW_FAIL", "0") == "1"
+        if allow_fail:
+            print(
+                f"[eval.gate.strict] WARN: {fail_count} failures detected but ALLOW_FAIL=1"
+            )
+            print("[eval.gate.strict] OK (override)")
+            return 0
+        else:
+            print(
+                f"[eval.gate.strict] FAIL: {fail_count} failures detected in strict profile"
+            )
+            return 1
+
+    print("[eval.gate.strict] OK: no failures in strict profile")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR introduces local-only hardening & one-command outputs:

**New scripts**
- `scripts/eval/build_snapshot.py` → `make eval.snapshot` (writes `share/eval/snapshot/` with manifest/thresholds/provenance snapshots)
- `scripts/eval/build_html_index.py` → `make eval.html` (writes `share/eval/index.html` with pass/fail badges and links)
- `scripts/eval/build_bundle.py` → `make eval.bundle` (writes `share/eval/bundles/eval_bundle_<ts>.tar.gz`)
- `scripts/eval/gate_strict.py` → `make eval.gate.strict` (fails if strict profile has failures; override via `ALLOW_FAIL=1`)

**Makefile targets** (local-only)
- `eval.snapshot`, `ci.eval.snapshot`
- `eval.html`, `ci.eval.html`
- `eval.bundle`, `ci.eval.bundle`
- `eval.gate.strict`, `ci.eval.gate.strict`

**Docs**
- `docs/PHASE8_EVAL.md` updated with snapshot, HTML, bundle, and strict gate sections.

**Governance**
- STRICT. No CI/order drift. Local-only utilities.

**Acceptance (executed locally)**
- `make eval.snapshot` → snapshot files written; SHA visible in provenance snapshot.
- `make eval.html` → `share/eval/index.html` created.
- `make eval.bundle` → tar.gz contains 33+ files.
- `make eval.gate.strict` → fails with strict 1 failure; passes with `ALLOW_FAIL=1`.
- `make ops.verify` → `[ops.verify] OK`.

## Summary by Sourcery

Introduce local-only evaluation utilities for Phase-8 including configuration snapshots, an HTML dashboard, bundle creation, policy diff, repair plan workflows, and a strict preflight gate, with corresponding Makefile targets and updated documentation.

New Features:
- Add make eval.snapshot and build_snapshot.py to freeze manifest, thresholds, and provenance
- Add make eval.html and build_html_index.py to generate an HTML dashboard with pass/fail badges
- Add make eval.bundle and build_bundle.py to package evaluation artifacts into a distributable tarball
- Add make eval.gate.strict and gate_strict.py to enforce zero failures under the strict profile with an override option
- Add make eval.policydiff and policy_diff.py to compare strict vs dev profile outcomes
- Add make eval.repairplan and apply_repair_plan.py to generate and apply a repair plan for missing endpoints

CI:
- Mirror new local-only eval targets under ci.* for CI usage

Documentation:
- Update PHASE8_EVAL.md with sections for repaired export, policy delta, config snapshots, HTML dashboard, bundle creation, and strict preflight gate