### PR TITLE
ops/eval: Phase-8 closeout — README/CHANGELOG, eval.open, integrity hook (local-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.8.1 — Phase-8 shipping UX (local-only)
+
+- **Embed badges in HTML**: Status badges now render inline in `share/eval/index.html`
+- **Strict packaging variant**: `eval.package.strict` fails fast if strict policy has FAILs
+- **Release manifest**: `share/eval/release_manifest.json` lists all artifacts with size + SHA256
+- **Manifest viewer**: Dashboard renders manifest summary + first 200 artifacts in expandable table
+- **Download-all bundle**: `eval.bundle.all` creates deterministic tar.gz of entire eval directory
+- **Integrity verifier**: `eval.verify.integrity` checks all artifacts against manifest hashes
+- **Convenience launcher**: `eval.open` opens dashboard in browser
+- **Governance hook**: `ops.verify` conditionally runs integrity verification when manifest exists
+
 ## v0.0.6 — Infra hardening
 
 - CI workflow (doctor + docs/rules checks)

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,15 @@ ci.eval.report:
 
 # Local repo ops verifier (prints decisive lines; no CI wiring)
 ops.verify:
+	@echo "[ops.verify] running"
+	@if [ -f share/eval/release_manifest.json ]; then \
+	  echo "[ops.verify] integrity check present → verifying"; \
+	  $(MAKE) eval.verify.integrity; \
+	else \
+	  echo "[ops.verify] no release_manifest.json → skipping integrity check"; \
+	fi
 	@python3 scripts/ops/verify_repo.py
+	@echo "[ops.verify] OK"
 
 # Identical to local; intentionally not part of CI
 ci.ops.verify:
@@ -451,3 +459,8 @@ eval.verify.integrity:
 
 ci.eval.verify.integrity:
 	@python3 scripts/eval/verify_integrity.py
+
+.PHONY: eval.open
+eval.open:
+	@echo "[eval.open] Opening dashboard..."
+	@python3 -c "import pathlib, webbrowser; p = pathlib.Path('share/eval/index.html').resolve(); print('[eval.open]', p); webbrowser.open(p.as_uri())"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ Gemantria follows a deterministic pipeline architecture with multiple safety gat
 - **Read-Only Bible DB**: Enforces separation between reference and working data
 - **Parameterized SQL**: Prevents SQL injection through query parameterization
 
+## 📦 Shipping UX (Local Evaluation Dashboard)
+
+Gemantria includes a polished evaluation system for local development and handoff:
+
+```bash
+# Generate complete evaluation package
+make eval.package
+
+# View interactive dashboard (opens browser)
+make eval.open
+
+# Download all artifacts as single bundle
+make eval.bundle.all
+```
+
+**Dashboard Features:**
+- **Status badges** embedded inline (PASS/FAIL/WARN indicators)
+- **Release manifest viewer** with artifact inventory (expandable table)
+- **Integrity verification** with hash checking
+- **Offline operation** (works without internet)
+
+**Artifacts include:**
+- HTML dashboard with embedded badges and manifest viewer
+- JSON reports, Markdown summaries, and CSV exports
+- Deterministic tar.gz bundle for handoff
+- Integrity verification reports
+
+See [`docs/PHASE8_EVAL.md`](docs/PHASE8_EVAL.md) for complete documentation.
+
 ## 🔧 Configuration
 
 ### Environment Variables

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -410,3 +410,12 @@ make eval.release_manifest
 Artifact:
 
 * `share/eval/release_manifest.json` — path, size, sha256 for all packaged artifacts.
+
+### Convenience
+```bash
+make eval.open
+```
+Opens the offline dashboard.
+
+### Governance
+When `share/eval/release_manifest.json` is present, `make ops.verify` now runs integrity verification as part of the ops gate.

--- a/scripts/eval/verify_integrity.py
+++ b/scripts/eval/verify_integrity.py
@@ -30,7 +30,7 @@ def main() -> int:
         path = a.get("path")
         exp_sha = a.get("sha256")
         exp_sz = a.get("size")
-        if not path or path == "release_manifest.json":
+        if not path or path in ("release_manifest.json", "integrity_report.txt"):
             continue
         fp = EVAL / path
         if not fp.exists():


### PR DESCRIPTION
## PR-018: Phase-8 closeout — README/CHANGELOG, eval.open, integrity hook (local-only)

**Verification results:**
- ✅ CHANGELOG.md updated with v0.8.1 shipping UX features
- ✅ README.md includes Shipping UX section with dashboard + bundle + integrity features
- ✅ `eval.open` target launches dashboard in browser
- ✅ `ops.verify` conditionally runs integrity verification (and passes)
- ✅ All linting checks pass

**Evidence tails:**
```bash
rg -n "eval\.open" Makefile
make eval.package && make ops.verify
sed -n '1,80p' CHANGELOG.md
rg -n "Shipping UX|bundle|integrity" README.md
```

## Summary by Sourcery

Close out Phase-8 by introducing a polished local evaluation UX—including an interactive dashboard, deterministic bundle, and integrity verification—and wiring up corresponding Makefile targets and documentation.

New Features:
- Add make eval.open target to launch the local evaluation dashboard in a browser
- Add make eval.bundle.all to produce a deterministic tar.gz bundle of all evaluation artifacts
- Add make eval.verify.integrity and integrate it into make ops.verify to perform hash-based artifact integrity checks

Enhancements:
- Update verify_integrity.py to skip integrity_report.txt during verification
- Update CHANGELOG.md to document the v0.8.1 Phase-8 shipping UX release

Documentation:
- Add Shipping UX section to README with instructions for eval.package, eval.open, eval.bundle.all, and eval.verify.integrity
- Add detailed PHASE8_EVAL.md documentation for local evaluation dashboard and governance hook