### PR TITLE
ops/eval: fast soft integrity cache (017a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ github-mcp-wrapper.sh
 share/
 !share/SHARE_MANIFEST.json
 !share/README.md
+.cache/

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -317,6 +317,40 @@ python scripts/verify_pr016_pr017.py --dsn "$GEMATRIA_DSN" \
 
 **Outputs:** `VERIFIER_PASS` on success; fails closed otherwise.
 
+### `eval/integrity_fast.py` — Fast Integrity Caching Wrapper
+
+**Purpose:** Caches integrity verification results by manifest fingerprint to speed up repeated runs of `ops.verify`.
+**Rule References:** 017a (Surgical Soft Integrity Caching)
+**Capabilities:**
+
+- **Manifest Fingerprinting**: Uses SHA-256 of release_manifest.json to detect changes
+- **Cache Storage**: Stores results in `.cache/integrity/` directory
+- **Timeout Protection**: Hard check limited to 180 seconds with graceful timeout handling
+- **Status Caching**: Caches pass/fail/timeout status with timestamps
+- **Skip on No Manifest**: Gracefully skips when manifest doesn't exist
+
+**Usage:**
+
+```bash
+# Called automatically by eval.verify.integrity.soft
+python scripts/eval/integrity_fast.py --manifest share/eval/release_manifest.json
+
+# Clear cache if needed
+make eval.cache.clear
+```
+
+**Cache Behavior:**
+
+- **First Run**: Executes hard check, caches result (may take ~100+ seconds)
+- **Subsequent Runs**: Returns cached result instantly when manifest unchanged
+- **Manifest Changes**: Invalidates cache and re-runs hard check
+- **No Manifest**: Skips with non-blocking status
+
+**Performance Impact:**
+- **First run**: ~100+ seconds (hard check execution time)
+- **Cached runs**: ~0.02 seconds (JSON file read)
+- **Cache invalidation**: Automatic on manifest changes
+
 ### rules_guard.py — Critical System Enforcement
 
 **Purpose:** System-level validation ensuring rules aren't just documentation. Fail-closed verification for code changes.

--- a/scripts/eval/integrity_fast.py
+++ b/scripts/eval/integrity_fast.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import argparse, hashlib, json, pathlib, subprocess, sys, time
+
+def sha256(b: bytes) -> str:
+    h = hashlib.sha256(); h.update(b); return h.hexdigest()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", required=True, help="Path to release_manifest.json")
+    ap.add_argument("--hard-cmd", default="make -s eval.verify.integrity",
+                    help="Command to run the hard integrity check once")
+    ap.add_argument("--cache-dir", default=".cache/integrity", help="Cache directory")
+    ap.add_argument("--timeout", type=int, default=180, help="Timeout (s) for hard check")
+    args = ap.parse_args()
+
+    man = pathlib.Path(args.manifest)
+    if not man.exists():
+        print(f"[integrity.fast] SKIP (no manifest: {man})")
+        print("[integrity] soft gate: SKIP (non-blocking)")
+        return 0
+
+    cache = pathlib.Path(args.cache_dir)
+    cache.mkdir(parents=True, exist_ok=True)
+    key = sha256(man.read_bytes())
+    stamp = cache / f"{key}.json"
+
+    if stamp.exists():
+        try:
+            meta = json.loads(stamp.read_text())
+            status = meta.get("status")
+            ts = meta.get("ts")
+            print(f"[integrity.fast] cache hit (status={status}, ts={ts})")
+            print(f"[integrity] soft gate: {str(status).upper()} (cached)")
+            return 0
+        except Exception:
+            pass  # fall through to recompute
+
+    print("[integrity.fast] cache miss → running hard check once…")
+    start = time.time()
+    try:
+        rc = subprocess.run(args.hard_cmd, shell=True, timeout=args.timeout).returncode
+    except subprocess.TimeoutExpired:
+        rc = 124
+
+    status = "pass" if rc == 0 else ("timeout" if rc == 124 else "fail")
+    stamp.write_text(json.dumps({"status": status, "rc": rc, "ts": time.time()}))
+    dur = time.time() - start
+    print(f"[integrity.fast] result={status} rc={rc} dur={dur:.2f}s")
+    print(f"[integrity] soft gate: {status.upper()} (non-blocking)")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 017a: Fast Soft Integrity (cache → sub-second re-runs)

**Scope:** strictly ops/eval verification speedups. No CI/order drift. Hard gates unchanged.

### What's in this PR
- **Soft integrity cache** (`eval.verify.integrity.soft` now consults a manifest-fingerprint cache).
- **Cache key**: `sha256` of `share/eval/release_manifest.json`.
- **Behavior**:
  - First run after manifest change: executes the hard check once; records `{status, ts}`.
  - Subsequent runs (same manifest): returns cached status instantly (~20–50 ms).
  - **Hard gate** (`make eval.verify.integrity`) remains unchanged and still blocks on mismatches.
- **ops.verify wired for speed**: uses the cached soft check; **never** triggers a rebuild/package.
- **Docs**: AGENTS.md updated to explain fast soft integrity + cache invalidation rules.

### Why
Local ops loops were waiting ~3 minutes for repeated soft checks. This introduces a safe cache keyed to the release manifest so we don't repeat work unnecessarily while preserving correctness.

### Acceptance (local)
- First soft run (no cache): prints `cache miss` and performs one hard check; records status.
- Second soft run (no changes): prints `cache hit` and returns immediately (<= 100 ms).
- `make eval.verify.integrity` still exits non-zero on mismatches.
- `make -s ops.verify` completes in <= 100 ms on cache hits and ends with `[ops.verify] OK`.
- Running ops.verify must **not** invoke package/bundle targets.

### Notes
- Cache invalidates automatically on any change to `share/eval/release_manifest.json` contents (hash change).
- No edits to governance, rules, or CI gates.

---
**Requested reviewers:** ops + CI maintainers.

## Summary by Sourcery

Introduce a fast soft integrity caching mechanism for eval.verify.integrity.soft to reduce repeated check times to sub-second by caching results keyed on the release manifest fingerprint while preserving the existing hard check gate behavior.

Enhancements:
- Add scripts/eval/integrity_fast.py to hash the release manifest, cache soft integrity results, and fallback to the hard integrity check with timeout
- Update Makefile to route eval.verify.integrity.soft through the caching wrapper and add an eval.cache.clear target for cache invalidation

Documentation:
- Document the fast soft integrity caching usage, behavior, and manifest-based invalidation rules in AGENTS.md