### PR TITLE
ci: add Makefile duplicate-target guard (024c; surgical)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,24 @@
 
 
 
+# ------------------------------------------------------------------
+# Duplicate Makefile target guard (CI smoke-friendly; no hard gate)
+# ------------------------------------------------------------------
+.PHONY: targets.check.dupes
+targets.check.dupes:
+	@dupes=$$(awk -F: '/^[[:alnum:]_.-][^:]*:/ { \
+	  if ($$1 !~ /^\.PHONY/) { \
+	    split($$1,a,/ +/); \
+	    for(i in a) if (a[i]!="" && a[i]!~/^\.PHONY/) print a[i] \
+	  } \
+	}' Makefile | sort | uniq -d); \
+	if [ -n "$$dupes" ]; then \
+	  echo "[targets.check.dupes] ERROR: duplicate targets found:"; \
+	  echo "$$dupes"; \
+	  exit 1; \
+	else \
+	  echo "[targets.check.dupes] OK: no duplicates"; \
+	fi
 
 .PHONY: py.quickfix py.longline py.fullwave
 py.quickfix:


### PR DESCRIPTION
Surgical replacement for 024b (scope-drifted).

### What
- Add `targets.check.dupes` to Makefile only.
  - CI smoke-friendly detection of duplicate Makefile targets.
  - No behavior change elsewhere.

### Why
- Keep duplicate-target guard as a micro, scope-pure change on `main`.

### Scope
- **Only** `Makefile` updated.

### Acceptance
- `make -s targets.check.dupes` → `[targets.check.dupes] OK: no duplicates`
- `make -s ops.verify` → ends `[ops.verify] OK` (fast path).

This PR supersedes #42.

## Summary by Sourcery

Build:
- Add targets.check.dupes to Makefile to flag duplicate targets