### PR TITLE
docs(templates-028): add PR & NEXT_STEPS templates + SSOT references primer

### DIFF
--- a/.cursor/templates/NEXT_STEPS.template.md
+++ b/.cursor/templates/NEXT_STEPS.template.md
@@ -1,0 +1,20 @@
+# NEXT_STEPS — <short goal> (Active v1)
+
+## References (REQUIRED)
+- **Rules cited:** <rule ids>
+- **Agents referenced:** <agent anchors>
+- **Docs touched:** <paths>
+- **SSOT links:** <anchors/sections>
+
+## Scope (only these files change)
+- <paths>
+
+## Steps
+- [ ] <step>
+      Evidence: <command + decisive tail lines>
+
+## Failure Policy
+- If a command fails: paste last 40 lines; STOP.
+
+## Merge Sequence
+- [ ] <ordered merges with evidence lines>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,23 @@
-# Summary
+## Title
+<!-- concise, imperative; include PR code (e.g., 024c), scope keyword -->
 
-- What this PR changes (1–3 bullets)
+## Summary
+<!-- what & why in 2–4 lines -->
 
-# Phase & Rules
+## References (REQUIRED)
+- **Rules cited:** <!-- e.g., 039-execution-contract; 040-ci-triage; 041-pr-merge-policy -->
+- **Agents referenced:** <!-- e.g., AGENTS.md#orchestrator; AGENTS.md#cursor -->
+- **Docs touched:** <!-- list relative paths -->
+- **SSOT links:** <!-- RULES_INDEX.md anchors; AGENTS.md anchors; SSOT_MASTER_PLAN.md sections -->
 
-- Phase: <!-- e.g., Phase 5 (PR-017) -->
-- Rules: <!-- e.g., 000,006,013,021,022,025,026-029 -->
+## Scope (files only)
+<!-- exact list; no others -->
 
-# Verification (paste raw)
+## Acceptance
+- [ ] `make -s ops.verify` → `[ops.verify] OK`
+- [ ] If Makefile edited: `make -s targets.check.dupes` → OK
+- [ ] No governance/workflow drift
+- [ ] CI green
 
-- VERIFIER output(s):
-- Head(≈200) of exports (if applicable):
-- WebUI test/build outputs (if applicable):
-
-# Docs Updated
-
-- [ ] AGENTS.md (affected dirs)
-- [ ] ADR (linked):
-- [ ] SSOT (schema / MASTER_PLAN / EPOCH_LEDGER)
-- [ ] Forest refreshed: `python scripts/generate_forest.py`
-
-# Notes
+## Evidence tails
+<!-- paste decisive tails or failing tails -->

--- a/docs/SSOT/REFERENCES.md
+++ b/docs/SSOT/REFERENCES.md
@@ -1,0 +1,11 @@
+# SSOT References Primer
+- **Rules index:** docs/SSOT/RULES_INDEX.md (authoritative list of active rules)
+- **Agents:** AGENTS.md (GPT-5 / Cursor roles & anchors)
+- **Master plan:** docs/SSOT/MASTER_PLAN.md
+- **Schemas:** docs/SSOT/*schema*.json (as applicable)
+
+Every PR & NEXT_STEPS must cite:
+1) Rules (by ID),
+2) Agents (anchors),
+3) Docs touched (paths),
+4) SSOT links (anchors).

--- a/share/RULES_INDEX.md
+++ b/share/RULES_INDEX.md
@@ -41,4 +41,6 @@
 | 036 | 036-temporal-visualization-spec.mdc | # --- |
 | 037 | 037-data-persistence-completeness.mdc | # --- |
 | 038 | 038-exports-smoke-gate.mdc | # --- |
-| 039 | 039-cursor-execution-contract.mdc | # --- |
+| 039 | 039-execution-contract.mdc | # id: 039_EXECUTION_CONTRACT |
+| 040 | 040-ci-triage-playbook.mdc | # id: 040_CI_TRIAGE_PLAYBOOK |
+| 041 | 041-pr-merge-policy.mdc | # id: 041_PR_MERGE_POLICY |

--- a/share/SSOT_MASTER_PLAN.md
+++ b/share/SSOT_MASTER_PLAN.md
@@ -128,5 +128,7 @@
 | 036 | # --- |
 | 037 | # --- |
 | 038 | # --- |
-| 039 | # --- |
+| 039 | # id: 039_EXECUTION_CONTRACT |
+| 040 | # id: 040_CI_TRIAGE_PLAYBOOK |
+| 041 | # id: 041_PR_MERGE_POLICY |
 <!-- RULES_TABLE_END -->


### PR DESCRIPTION
Adds mandatory templates to enforce references discipline in every PR and runbook.

### What
- **.github/pull_request_template.md** — requires 4 reference blocks (Rules, Agents, Docs, SSOT) + acceptance + evidence tails.
- **.cursor/templates/NEXT_STEPS.template.md** — authoritative runbook skeleton with required references, scope, steps, failure policy.
- **docs/SSOT/REFERENCES.md** — primer pointing to RULES_INDEX.md, AGENTS.md anchors, MASTER_PLAN, schemas.

### Why
- Guarantees Cursor always cites the rules/agents/docs to use, without relying on chat context.
- Locks the v3.7 contract’s “references & templates required” policy into the repo.

### Scope
- Docs/templates only. No workflow/governance changes.

### Acceptance
- Pre-commit hooks green (repo.audit/docs.audit/share.sync).
- `make -s ops.verify` fast path ends `[ops.verify] OK`.

Labels: rules, docs, templates.