### PR TITLE
ci: nightly mypy sweep (non-blocking) + Make targets (053)

### DIFF
--- a/.github/workflows/typing-nightly.yml
+++ b/.github/workflows/typing-nightly.yml
@@ -1,0 +1,56 @@
+name: typing-nightly
+on:
+  schedule:
+    - cron: "17 7 * * *" # daily 07:17 UTC
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  mypy-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps (project + mypy)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install mypy types-requests types-PyYAML
+
+      - name: Run full mypy sweep (non-blocking)
+        id: mypy
+        continue-on-error: true
+        run: |
+          set -e
+          mkdir -p share/eval/mypy
+          # Full sweep using repo config (mypy.ini)
+          mypy --config-file=mypy.ini --ignore-missing-imports | tee share/eval/mypy/mypy_full.txt || true
+          # Count errors (lines containing ": error:")
+          ERRORS=$(grep -E ":[0-9]+:[0-9]+: error:" -c share/eval/mypy/mypy_full.txt || true)
+          echo "errors=${ERRORS}" >> "$GITHUB_OUTPUT"
+          # Emit standardized hint line for CI triage
+          if [ -f scripts/hint.sh ]; then
+            bash scripts/hint.sh "mypy-nightly: errors=${ERRORS}"
+          else
+            echo "HINT: mypy-nightly: errors=${ERRORS}"
+          fi
+
+      - name: Upload mypy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mypy_full_report
+          path: share/eval/mypy/mypy_full.txt
+
+      - name: Summarize
+        run: |
+          echo "Nightly mypy errors: ${{ steps.mypy.outputs.errors }}"

--- a/Makefile
+++ b/Makefile
@@ -552,3 +552,16 @@ eval.provenance:
 
 ci.eval.provenance:
 	@python3 scripts/eval/build_provenance.py
+
+## Typing (mypy) — convenience targets
+.PHONY: ci.mypy.full
+ci.mypy.full:
+	@echo "[ci.mypy.full] Running repository-wide mypy sweep..."
+	@mypy --config-file=mypy.ini --ignore-missing-imports || true
+
+.PHONY: ci.mypy.changed
+ci.mypy.changed:
+	@echo "[ci.mypy.changed] Running mypy on changed files (against main)..."
+	@CHANGED=$$(git diff --name-only origin/main...HEAD | grep -E '\.py$$' || true); \
+	if [ -z "$$CHANGED" ]; then echo "No changed Python files."; exit 0; fi; \
+	mypy --config-file=mypy.ini --ignore-missing-imports $$CHANGED || true

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ pre-commit run -a    # ruff, black, mypy, audits, share.sync
 make ci.smart        # smart strict/soft choice + audits\nmake ci              # mirrors CI locally (legacy)
 ```
 CI workflow lives in `.github/workflows/ci.yml`.
+Nightly typing: non-blocking full-repo mypy report (see Actions → typing-nightly).
 
 ---
 


### PR DESCRIPTION
## 🔍 **CI Enhancement: Nightly MyPy Sweep (053)**

### **Goal**
Add non-blocking nightly typing scan to track legacy type debt without blocking PRs.

### **Changes Made**
- ✅ **New workflow**: `.github/workflows/typing-nightly.yml` - Scheduled daily 07:17 UTC full-repo mypy sweep
- ✅ **Non-blocking**: Uses `continue-on-error: true` so it never fails CI
- ✅ **Artifact upload**: MyPy report saved as `mypy_full_report` for review
- ✅ **Emitted hints**: Standardized `HINT: mypy-nightly: errors=X` for triage
- ✅ **Make targets**: `ci.mypy.full` (full sweep) and `ci.mypy.changed` (changed files only)
- ✅ **README nudge**: Added single line about nightly typing reports

### **Files Changed**
- `.github/workflows/typing-nightly.yml` (new file, 50 lines)
- `Makefile` - Added typing targets (12 lines)
- `README.md` - Added nightly typing mention (1 line)

### **Emitted Hints**
- `HINT: ci: nightly mypy sweep added (non-blocking)`
- `HINT: mypy-nightly: errors=<count>`

### **Rules/Agents/Docs/SSOT References**
- **Rules**: 039-041 (CI triage, emitted hints, governance)
- **Agents**: OPS mode v4.0 - surgical changes, evidence-based merging
- **Docs**: PR templates, NEXT_STEPS.md discipline
- **SSOT**: CI workflows as source of truth for quality gates