### PR TITLE
ci: nightly ruff sweep (non-blocking) + Make targets (054)

### DIFF
--- a/.github/workflows/lint-nightly.yml
+++ b/.github/workflows/lint-nightly.yml
@@ -1,0 +1,56 @@
+name: lint-nightly
+on:
+  schedule:
+    - cron: "17 7 * * *" # daily 07:17 UTC (same as mypy-nightly)
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  lint-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps (project + ruff)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ruff
+
+      - name: Run full ruff lint sweep (non-blocking)
+        id: lint
+        continue-on-error: true
+        run: |
+          set -e
+          mkdir -p share/eval/lint
+          # Full sweep using ruff (no --fix to avoid modifying code)
+          ruff check src scripts tools | tee share/eval/lint/ruff_full.txt || true
+          # Count violations (lines containing file:line:col: code)
+          VIOLATIONS=$(grep -E "^[^[:space:]]+\.py:[0-9]+:[0-9]+: " -c share/eval/lint/ruff_full.txt || true)
+          echo "violations=${VIOLATIONS}" >> "$GITHUB_OUTPUT"
+          # Emit standardized hint line for CI triage
+          if [ -f scripts/hint.sh ]; then
+            bash scripts/hint.sh "lint-nightly: violations=${VIOLATIONS}"
+          else
+            echo "HINT: lint-nightly: violations=${VIOLATIONS}"
+          fi
+
+      - name: Upload ruff report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruff_full_report
+          path: share/eval/lint/ruff_full.txt
+
+      - name: Summarize
+        run: |
+          echo "Nightly ruff violations: ${{ steps.lint.outputs.violations }}"

--- a/Makefile
+++ b/Makefile
@@ -565,3 +565,16 @@ ci.mypy.changed:
 	@CHANGED=$$(git diff --name-only origin/main...HEAD | grep -E '\.py$$' || true); \
 	if [ -z "$$CHANGED" ]; then echo "No changed Python files."; exit 0; fi; \
 	mypy --config-file=mypy.ini --ignore-missing-imports $$CHANGED || true
+
+## Linting (ruff) — convenience targets
+.PHONY: ci.lint.full
+ci.lint.full:
+	@echo "[ci.lint.full] Running repository-wide ruff lint sweep..."
+	@ruff check src scripts tools || true
+
+.PHONY: ci.lint.changed
+ci.lint.changed:
+	@echo "[ci.lint.changed] Running ruff on changed files (against main)..."
+	@CHANGED=$$(git diff --name-only origin/main...HEAD | grep -E '\.py$$' || true); \
+	if [ -z "$$CHANGED" ]; then echo "No changed Python files."; exit 0; fi; \
+	ruff check $$CHANGED || true

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ make ci.smart        # smart strict/soft choice + audits\nmake ci              #
 ```
 CI workflow lives in `.github/workflows/ci.yml`.
 Nightly typing: non-blocking full-repo mypy report (see Actions → typing-nightly).
+Nightly linting: non-blocking full-repo ruff report (see Actions → lint-nightly).
 
 ---
 


### PR DESCRIPTION

Surgical CI enhancement mirroring typing-nightly:

- New workflow: .github/workflows/lint-nightly.yml
  • Runs daily full-repo ruff sweep (non-blocking, artifacts uploaded)
  • Emits HINT: ruff-nightly: count=<N>

- Make targets:
  • make ci.lint.full      → repository-wide ruff (non-blocking)
  • make ci.lint.changed   → ruff on files changed vs origin/main

- README: add one-line mention under CI/Quality

Acceptance:
- ops.verify → [ops.verify] OK
- PR checks green (fork-safe; non-blocking nightly)
- Artifact present: ruff_full_report
