### PR TITLE
ci: add soft warning thresholds to nightly metrics (058)

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -55,6 +55,18 @@ jobs:
             echo "HINT: coverage-nightly: percent=$(printf '%.2f' "$pct")"
           fi
 
+      - name: Soft threshold (non-fatal warning)
+        env:
+          PERCENT: ${{ steps.covpct.outputs.percent }}
+          COVERAGE_WARN_MIN: ${{ vars.COVERAGE_WARN_MIN }}
+        run: |
+          CM="${COVERAGE_WARN_MIN:-}"
+          P="${PERCENT:-0}"
+          if [ -n "$CM" ]; then
+            # Use awk for floating point comparison
+            echo "$P $CM" | awk '{if ($1 < $2) print "HINT: coverage-nightly WARN: percent=" $1 " < COVERAGE_WARN_MIN=" $2}'
+          fi
+
       - name: Append coverage metric to history (JSONL)
         env:
           PERCENT: ${{ steps.covpct.outputs.percent }}

--- a/.github/workflows/lint-nightly.yml
+++ b/.github/workflows/lint-nightly.yml
@@ -44,6 +44,17 @@ jobs:
             echo "HINT: ruff-nightly: count=${COUNT}"
           fi
 
+      - name: Soft threshold (non-fatal warning)
+        env:
+          COUNT: ${{ steps.ruff.outputs.count }}
+          LINT_WARN_MAX: ${{ vars.LINT_WARN_MAX }}
+        run: |
+          LW="${LINT_WARN_MAX:-}"
+          C="${COUNT:-0}"
+          if [ -n "$LW" ] && [ "$C" -gt "$LW" ]; then
+            echo "HINT: ruff-nightly WARN: count=$C > LINT_WARN_MAX=$LW"
+          fi
+
       - name: Append ruff metric to history (JSONL)
         env:
           COUNT: ${{ steps.ruff.outputs.count }}

--- a/.github/workflows/typing-nightly.yml
+++ b/.github/workflows/typing-nightly.yml
@@ -45,6 +45,17 @@ jobs:
             echo "HINT: mypy-nightly: errors=${ERRORS}"
           fi
 
+      - name: Soft threshold (non-fatal warning)
+        env:
+          ERRORS: ${{ steps.mypy.outputs.errors }}
+          TYPING_WARN_MAX: ${{ vars.TYPING_WARN_MAX }}
+        run: |
+          TW="${TYPING_WARN_MAX:-}"
+          E="${ERRORS:-0}"
+          if [ -n "$TW" ] && [ "$E" -gt "$TW" ]; then
+            echo "HINT: mypy-nightly WARN: errors=$E > TYPING_WARN_MAX=$TW"
+          fi
+
       - name: Append mypy metric to history (JSONL)
         env:
           ERRORS: ${{ steps.mypy.outputs.errors }}


### PR DESCRIPTION
Adds optional soft thresholds to all nightly quality jobs.

- typing-nightly → warns when errors > ${{ vars.TYPING_WARN_MAX }}
- lint-nightly   → warns when count  > ${{ vars.LINT_WARN_MAX }}
- coverage-nightly → warns when percent < ${{ vars.COVERAGE_WARN_MIN }}

All warnings emit standardized HINT lines. Jobs remain non-blocking. Configure via repo **Actions → Variables**; if unset, no warnings are emitted.

Acceptance:
- ops.verify → [ops.verify] OK
- PR checks green
- Nightlies still succeed; when variables are set, WARN HINTs appear if thresholds crossed
