### PR TITLE
docs: add Quality Dashboard doc (060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ CI workflow lives in `.github/workflows/ci.yml`.
 Nightly typing: non-blocking full-repo mypy report (see Actions → typing-nightly).
 Nightly linting: non-blocking full-repo ruff report (see Actions → lint-nightly).
 Nightly coverage: non-blocking full-repo pytest coverage (see Actions → coverage-nightly).
+- See also: [Quality Dashboard](share/eval/QUALITY_DASHBOARD.md)
 
 ### Nightly Workflow Status
 ![typing-nightly](https://github.com/iog-creator/Gemantria/actions/workflows/typing-nightly.yml/badge.svg)

--- a/share/eval/QUALITY_DASHBOARD.md
+++ b/share/eval/QUALITY_DASHBOARD.md
@@ -1,0 +1,24 @@
+# Quality Dashboard (Nightly)
+
+**What we track (nightly, non-blocking):**
+- **Typing (MyPy):** error count (`mypy_history` artifact, JSONL)
+- **Lint (Ruff):** issue count (`ruff_history` artifact, JSONL)
+- **Coverage:** percent (`coverage_history` artifact, JSONL)
+
+**Where to see results:**
+- Actions → *typing-nightly*, download: `mypy_full_report`, `mypy_history`
+- Actions → *lint-nightly*, download: `ruff_full_report`, `ruff_history`
+- Actions → *coverage-nightly*, download: `coverage_report`, `coverage_history`
+
+**Badges:**
+If `ALLOW_BADGE_COMMITS=true`:
+- Rendered in README from `share/eval/badges/*.svg`
+Else:
+- Grab `quality_badges` artifact from the *quality-badges* workflow.
+
+**Threshold warnings (optional):**
+- Set repo variables:
+  - `TYPING_WARN_MAX` (int), `LINT_WARN_MAX` (int), `COVERAGE_WARN_MIN` (float)
+- Nightlies will emit **HINT: … WARN:** lines when exceeded (jobs still succeed).
+
+**Governance note:** Nightlies are **observability only** — they never block PRs.


### PR DESCRIPTION
Adds a read-only dashboard doc that links nightly artifacts (reports + histories), explains the metrics and optional thresholds, and describes how the badges workflow works.

- Doc: share/eval/QUALITY_DASHBOARD.md
- README: link to dashboard under Nightly section

Acceptance:
- ops.verify → [ops.verify] OK
- PR checks green
- Document renders and links are readable
