### PR TITLE
ci: formatter harmonization (ruff-format only) (066)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           pip install -r requirements.txt || true
           pip install pre-commit ruff mypy pytest
 
+      - name: Tooling versions
+        run: |
+          ruff --version || true
+          mypy --version || true
+
       # PRs: run on the diff (base→head)
       - name: Pre-commit (PR diff)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,10 @@ repos:
     rev: v0.6.9
     hooks:
       - id: ruff
-        args: [--fix]
+        args: [--output-format=github]
       - id: ruff-format
-
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
+        # ruff-format is the single source of truth for formatting now
+        args: []
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.0

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,23 @@ py.longline:
 py.fullwave: py.quickfix py.longline
 	@make py.format && make py.lint
 
+.PHONY: fmt fmt.check lint lint.fix
+fmt:
+	@echo "[fmt] Applying ruff-format..."
+	@ruff format .
+
+fmt.check:
+	@echo "[fmt.check] Checking format (no changes)..."
+	@ruff format --check .
+
+lint:
+	@echo "[lint] Running ruff check..."
+	@ruff check .
+
+lint.fix:
+	@echo "[lint.fix] Running ruff check with fixes..."
+	@ruff check . --fix
+
 .PHONY: test.smoke test.smoke.strict
 test.smoke:
 	pytest -q --no-cov -m smoke tests/smoke || true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+line-length = 88
+target-version = "py311"
+
+[lint]
+select = ["E","F","I","UP","B","RUF"]
+ignore = []
+
+[format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
Removes Black hook to prevent ruff↔black oscillation and standardizes on ruff-format.
Adds ruff.toml (line-length 88, py311), make targets (fmt, fmt.check, lint, lint.fix),
and CI tooling version echo. Pinned to ruff v0.6.9 (matches CI).

Acceptance:
- ops.verify → [ops.verify] OK
- PR checks green without formatter flip-flop
- pre-commit on local and CI produce identical results