### PR TITLE
rules(068): add 042–048 and regenerate mirrors

### DIFF
--- a/.cursor/rules/042-formatter-single-source-of-truth.mdc
+++ b/.cursor/rules/042-formatter-single-source-of-truth.mdc
@@ -1,0 +1,4 @@
+# 042 — Formatter Single Source of Truth (AlwaysApply)
+- Use **ruff-format** only; Black is not allowed in CI/pre-commit.
+- Keep `ruff.toml` with line-length and Python version.
+- CI runs `ruff format --check` and `ruff check` (PR-diff scoped for PRs; full on main).

--- a/.cursor/rules/043-ci-db-bootstrap.mdc
+++ b/.cursor/rules/043-ci-db-bootstrap.mdc
@@ -1,0 +1,3 @@
+# 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply)
+- Any workflow that queries the DB must create DB + run all migrations first.
+- Empty datasets are allowed; graph stats may report zeros; density=0; jobs must not fail on emptiness.

--- a/.cursor/rules/044-share-manifest-contract.mdc
+++ b/.cursor/rules/044-share-manifest-contract.mdc
@@ -1,0 +1,3 @@
+# 044 — Share Manifest Contract (AlwaysApply)
+- New `share/**` artifacts require a manifest entry with realistic `max_bytes`.
+- Workflows refresh share before checking; optional artifacts emit HINT and skip, not fail PRs.

--- a/.cursor/rules/045-rerank-blend-SSOT.mdc
+++ b/.cursor/rules/045-rerank-blend-SSOT.mdc
@@ -1,0 +1,3 @@
+# 045 — Rerank Blend is SSOT (AlwaysApply)
+- `edge_strength = 0.5*cosine + 0.5*rerank` (or SSOT `EDGE_ALPHA`).
+- Thresholds: strong ≥ 0.90; weak ≥ 0.75; code & SSOT docs must change together.

--- a/.cursor/rules/046-ci-hermetic-fallbacks.mdc
+++ b/.cursor/rules/046-ci-hermetic-fallbacks.mdc
@@ -1,0 +1,3 @@
+# 046 — Hermetic CI Fallbacks (AlwaysApply)
+- No outbound inference in CI; use deterministic mocks (e.g., `MOCK_AI=1`).
+- Nightlies/observability steps emit HINTs and continue (non-blocking).

--- a/.cursor/rules/047-nightly-metrics-contract.mdc
+++ b/.cursor/rules/047-nightly-metrics-contract.mdc
@@ -1,0 +1,3 @@
+# 047 — Nightly Metrics Contract (AlwaysApply)
+- Nightlies produce JSONL history artifacts and standardized HINT lines.
+- Badges workflow is artifact-first; auto-commit is optional via repo variable.

--- a/.cursor/rules/048-agents-docs-coverage.mdc
+++ b/.cursor/rules/048-agents-docs-coverage.mdc
@@ -1,0 +1,2 @@
+# 048 — Agent Docs Coverage for New Modules (AlwaysApply)
+- New modules touching DB/AI must update AGENTS.md with contracts/pipelines/ownership.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,4 +133,11 @@ Counts are emitted to `share/eval/edges/edge_class_counts.json` for telemetry.
 | 039 | # id: 039_EXECUTION_CONTRACT |
 | 040 | # id: 040_CI_TRIAGE_PLAYBOOK |
 | 041 | # id: 041_PR_MERGE_POLICY |
+| 042 | # 042 — Formatter Single Source of Truth (AlwaysApply) |
+| 043 | # 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply) |
+| 044 | # 044 — Share Manifest Contract (AlwaysApply) |
+| 045 | # 045 — Rerank Blend is SSOT (AlwaysApply) |
+| 046 | # 046 — Hermetic CI Fallbacks (AlwaysApply) |
+| 047 | # 047 — Nightly Metrics Contract (AlwaysApply) |
+| 048 | # 048 — Agent Docs Coverage for New Modules (AlwaysApply) |
 <!-- RULES_INVENTORY_END -->

--- a/docs/SSOT/MASTER_PLAN.md
+++ b/docs/SSOT/MASTER_PLAN.md
@@ -131,4 +131,11 @@
 | 039 | # id: 039_EXECUTION_CONTRACT |
 | 040 | # id: 040_CI_TRIAGE_PLAYBOOK |
 | 041 | # id: 041_PR_MERGE_POLICY |
+| 042 | # 042 — Formatter Single Source of Truth (AlwaysApply) |
+| 043 | # 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply) |
+| 044 | # 044 — Share Manifest Contract (AlwaysApply) |
+| 045 | # 045 — Rerank Blend is SSOT (AlwaysApply) |
+| 046 | # 046 — Hermetic CI Fallbacks (AlwaysApply) |
+| 047 | # 047 — Nightly Metrics Contract (AlwaysApply) |
+| 048 | # 048 — Agent Docs Coverage for New Modules (AlwaysApply) |
 <!-- RULES_TABLE_END -->

--- a/docs/SSOT/RULES_INDEX.md
+++ b/docs/SSOT/RULES_INDEX.md
@@ -44,3 +44,10 @@
 | 039 | 039-execution-contract.mdc | # id: 039_EXECUTION_CONTRACT |
 | 040 | 040-ci-triage-playbook.mdc | # id: 040_CI_TRIAGE_PLAYBOOK |
 | 041 | 041-pr-merge-policy.mdc | # id: 041_PR_MERGE_POLICY |
+| 042 | 042-formatter-single-source-of-truth.mdc | # 042 — Formatter Single Source of Truth (AlwaysApply) |
+| 043 | 043-ci-db-bootstrap.mdc | # 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply) |
+| 044 | 044-share-manifest-contract.mdc | # 044 — Share Manifest Contract (AlwaysApply) |
+| 045 | 045-rerank-blend-SSOT.mdc | # 045 — Rerank Blend is SSOT (AlwaysApply) |
+| 046 | 046-ci-hermetic-fallbacks.mdc | # 046 — Hermetic CI Fallbacks (AlwaysApply) |
+| 047 | 047-nightly-metrics-contract.mdc | # 047 — Nightly Metrics Contract (AlwaysApply) |
+| 048 | 048-agents-docs-coverage.mdc | # 048 — Agent Docs Coverage for New Modules (AlwaysApply) |

--- a/scripts/audit_quant.py
+++ b/scripts/audit_quant.py
@@ -26,7 +26,7 @@ def audit_model_on_port(port: int, name: str) -> dict[str, str]:
         return {
             "name": "error",
             "quant": "error",
-            "status": f"connection_failed: {str(e)}",
+            "status": f"connection_failed: {e!s}",
         }
 
 

--- a/scripts/book_readiness.py
+++ b/scripts/book_readiness.py
@@ -69,7 +69,7 @@ def _load_cfg(config_path):
     config_path = Path(config_path)
     with open(config_path) as f:
         if config_path.suffix.lower() in (".yaml", ".yml"):
-            import yaml  # type: ignore  # noqa: E402
+            import yaml  # type: ignore
 
             return yaml.safe_load(f)
         return json.load(f)
@@ -121,7 +121,7 @@ def _collect_metrics(stats_path, temporal_path, forecast_path):
             ) / total_edges
 
     # Correlation metrics
-    if "correlations" in stats and stats["correlations"]:
+    if stats.get("correlations"):
         corrs = [c["cosine"] for c in stats["correlations"] if "cosine" in c]
         if corrs:
             metrics["cosine_min"] = min(corrs)
@@ -201,7 +201,7 @@ def cmd_compute(args):
 
 def cmd_gate(args):
     """Validate head artifacts against SSOT schemas. HARD-REQUIRED."""
-    import json  # noqa: E402
+    import json
 
     # Load existing report
     if not READINESS_JSON.exists():
@@ -224,7 +224,7 @@ def cmd_gate(args):
 
     # Validate graph stats schema
     try:
-        from jsonschema import ValidationError, validate  # noqa: E402
+        from jsonschema import ValidationError, validate
 
         # Graph stats schema
         schema_path = Path("docs/SSOT/graph-stats.schema.json")
@@ -264,7 +264,7 @@ def cmd_gate(args):
         schema_errs.append(f"Schema validation error: {e.message}")
     except Exception as e:
         schema_ok = False
-        schema_errs.append(f"Schema validation failed: {str(e)}")
+        schema_errs.append(f"Schema validation failed: {e!s}")
 
     # Update report
     report["schema"] = {"validated": schema_ok, "errors": schema_errs}

--- a/scripts/check_cursor_always_apply.py
+++ b/scripts/check_cursor_always_apply.py
@@ -29,12 +29,10 @@ def main() -> None:
         if m and p.name not in ALLOWED:
             offenders.append(p.name)
     if offenders:
-        msg = f"only 000/010/030 may be alwaysApply; found: {', '.join(offenders)}"  # noqa: E501
+        msg = f"only 000/010/030 may be alwaysApply; found: {', '.join(offenders)}"
         print(f"[rules.navigator.check] FAIL: {msg}", file=sys.stderr)
         sys.exit(2)
-    print(
-        "[rules.navigator.check] PASS: only navigators are alwaysApply (000/010/030)"
-    )  # noqa: E501
+    print("[rules.navigator.check] PASS: only navigators are alwaysApply (000/010/030)")
 
 
 if __name__ == "__main__":

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -85,7 +85,7 @@ def compare_env_sources() -> None:
 
 def check_postgres():
     try:
-        import psycopg  # noqa: E402
+        import psycopg
 
         dsn = os.environ.get("GEMATRIA_DSN", "")
         if not dsn:
@@ -110,9 +110,9 @@ def check_postgres():
 
 
 def check_lmstudio():
-    import time  # noqa: E402
+    import time
 
-    import requests  # noqa: E402
+    import requests
 
     host = os.environ.get("LM_STUDIO_HOST", "")
     if not host:

--- a/scripts/eval/anomalies.py
+++ b/scripts/eval/anomalies.py
@@ -91,10 +91,10 @@ def main() -> int:
         ):
             lines.append("## ⚠️ Referential Integrity (counts)")
             lines.append(
-                f"- missing_endpoints={c.get('missing_endpoints',0)} "
-                f"self_loops={c.get('self_loops',0)} "
-                f"dup_node_ids={c.get('duplicate_node_ids',0)} "
-                f"dup_edge_pairs={c.get('duplicate_edge_pairs',0)}"
+                f"- missing_endpoints={c.get('missing_endpoints', 0)} "
+                f"self_loops={c.get('self_loops', 0)} "
+                f"dup_node_ids={c.get('duplicate_node_ids', 0)} "
+                f"dup_edge_pairs={c.get('duplicate_edge_pairs', 0)}"
             )
             lines.append("")
 

--- a/scripts/eval/anomaly_badge.py
+++ b/scripts/eval/anomaly_badge.py
@@ -50,7 +50,7 @@ def badge(count: int) -> str:
   <linearGradient id="g" x2="0" stop-color="#bbb" stop-opacity=".1"/>
   <stop offset="1" stop-opacity=".1"/>
   <rect rx="3" width="{width}" height="20" fill="#555"/>
-  <rect rx="3" x="55" width="{width-55}" height="20" fill="{color}"/>
+  <rect rx="3" x="55" width="{width - 55}" height="20" fill="{color}"/>
   <path fill="{color}" d="M55 0h4v20h-4z"/>
   <rect rx="3" width="{width}" height="20" fill="url(#g)"/>
   <g fill="#fff" text-anchor="start"

--- a/scripts/eval/apply_remediation.py
+++ b/scripts/eval/apply_remediation.py
@@ -232,6 +232,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    import sys  # noqa: E402
+    import sys
 
     sys.exit(main())

--- a/scripts/eval/apply_rerank_refresh.py
+++ b/scripts/eval/apply_rerank_refresh.py
@@ -44,7 +44,7 @@ def main() -> int:
         )
     GRAPH.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
     path_str = GRAPH.relative_to(ROOT)
-    print(  # noqa: E501
+    print(
         f"[rerank.refresh] updated edges={len(edges)} (filled_from_provider={filled}) → {path_str}"
     )
     return 0

--- a/scripts/eval/build_badges.py
+++ b/scripts/eval/build_badges.py
@@ -14,12 +14,12 @@ def _badge(label: str, value: str, color: str) -> str:
     return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20" role="img" aria-label="{text}">
   <linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
   <rect rx="3" width="{w}" height="20" fill="#555"/>
-  <rect rx="3" x="55" width="{w-55}" height="20" fill="{color}"/>
+  <rect rx="3" x="55" width="{w - 55}" height="20" fill="{color}"/>
   <path fill="{color}" d="M55 0h4v20h-4z"/>
   <rect rx="3" width="{w}" height="20" fill="url(#a)"/>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="28" y="14">{label}</text>
-    <text x="{(55 + (w-55)/2):.0f}" y="14">{value}</text>
+    <text x="{(55 + (w - 55) / 2):.0f}" y="14">{value}</text>
   </g>
 </svg>"""
 

--- a/scripts/eval/build_html_index.py
+++ b/scripts/eval/build_html_index.py
@@ -234,7 +234,7 @@ def main() -> int:
     )
     html.append(
         "                summary.textContent = `Artifacts: ${data.artifact_count} | "
-        "Generated: ${new Date(data.generated_at * 1000).toISOString()}`;"  # noqa: E501
+        "Generated: ${new Date(data.generated_at * 1000).toISOString()}`;"
     )
     html.append("                const artifacts = data.artifacts.slice(0, 200);")
     html.append("                tbody.innerHTML = '';")

--- a/scripts/eval/build_release_notes.py
+++ b/scripts/eval/build_release_notes.py
@@ -71,7 +71,7 @@ def main() -> int:
             "exports_count": (prov.get("exports", {}) or {}).get("count"),
         }
         lines.append("```json")
-        import json as _json  # noqa: E402
+        import json as _json
 
         lines.append(_json.dumps(pv, indent=2, sort_keys=True))
         lines.append("```")

--- a/scripts/eval/build_remediation_plan.py
+++ b/scripts/eval/build_remediation_plan.py
@@ -213,7 +213,9 @@ def _generate_summary(remediations: list[dict[str, Any]]) -> dict[str, Any]:
         "estimated_total_effort": (
             "high"
             if severities["high"] > 0
-            else "medium" if severities["medium"] > 2 else "low"
+            else "medium"
+            if severities["medium"] > 2
+            else "low"
         ),
     }
 
@@ -323,6 +325,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    import sys  # noqa: E402
+    import sys
 
     sys.exit(main())

--- a/scripts/eval/build_snapshot.py
+++ b/scripts/eval/build_snapshot.py
@@ -59,7 +59,7 @@ def main() -> int:
     }
 
     provenance_snapshot = SNAPSHOT_DIR / "provenance.snapshot.json"
-    import json  # noqa: E402
+    import json
 
     provenance_snapshot.write_text(
         json.dumps(provenance, indent=2, sort_keys=True), encoding="utf-8"

--- a/scripts/eval/make_quality_badge.py
+++ b/scripts/eval/make_quality_badge.py
@@ -14,7 +14,7 @@ def badge(text, ok=True):
     return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20" role="img" aria-label="quality:{text}">
   <linearGradient id="g" x2="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/>
   <rect rx="3" width="{w}" height="20" fill="#555"/>
-  <rect rx="3" x="60" width="{w-60}" height="20" fill="{color}"/>
+  <rect rx="3" x="60" width="{w - 60}" height="20" fill="{color}"/>
   <path fill="{color}" d="M60 0h4v20h-4z"/>
   <rect rx="3" width="{w}" height="20" fill="url(#g)"/>
   <g fill="#fff" text-anchor="start" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -17,7 +17,7 @@ MD_OUT = OUTDIR / "report.md"
 
 def _read_yaml(path: pathlib.Path) -> Any:
     try:
-        import yaml  # type: ignore  # noqa: E402
+        import yaml  # type: ignore
 
         with open(path, encoding="utf-8") as f:
             return yaml.safe_load(f)
@@ -183,7 +183,7 @@ def task_json_assert(args: dict[str, Any]) -> dict[str, Any]:
 
 def task_json_schema(args: dict[str, Any]) -> dict[str, Any]:
     try:
-        import jsonschema  # type: ignore  # noqa: E402
+        import jsonschema  # type: ignore
     except Exception:
         return {
             "status": "FAIL",
@@ -328,7 +328,7 @@ def task_id_type_audit(args: dict[str, Any]) -> dict[str, Any]:
         return "other"
 
     types = [_type_name(v) for v in ids]
-    from collections import Counter  # noqa: E402
+    from collections import Counter
 
     counts = Counter(types)
 

--- a/scripts/eval/report_for_file.py
+++ b/scripts/eval/report_for_file.py
@@ -35,7 +35,7 @@ def main() -> int:
     try:
         MANIFEST.write_text(patched, encoding="utf-8")
         # import and run report.py as a module
-        import runpy  # noqa: E402
+        import runpy
 
         runpy.run_path(str(REPORT))
     finally:

--- a/scripts/eval/report_id_stability.py
+++ b/scripts/eval/report_id_stability.py
@@ -22,7 +22,7 @@ def _load_json(p: pathlib.Path) -> Any:
 
 
 def _read_yaml(path: pathlib.Path):
-    import yaml  # dev-only dep  # noqa: E402
+    import yaml  # dev-only dep
 
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 

--- a/scripts/eval/rerank_provider.py
+++ b/scripts/eval/rerank_provider.py
@@ -38,8 +38,8 @@ def _write_cache(key: str, payload: dict[str, str | float]) -> None:
 
 def _provider_lmstudio(a: str, b: str) -> float:
     # Local-only LM Studio HTTP provider (optional). If not configured, raises.
-    import json as _json  # noqa: E402
-    import urllib.request  # noqa: E402
+    import json as _json
+    import urllib.request
 
     url = os.environ.get("LMSTUDIO_RERANK_URL", "http://127.0.0.1:1234/v1/rerank")
     model = os.environ.get("LMSTUDIO_RERANK_MODEL", "qwen2.5-rerank")

--- a/scripts/eval/run_with_profile.py
+++ b/scripts/eval/run_with_profile.py
@@ -10,7 +10,7 @@ REPORT = ROOT / "scripts" / "eval" / "report.py"
 
 
 def _read_yaml(p: pathlib.Path) -> dict[str, Any]:
-    import yaml  # noqa: E402
+    import yaml
 
     return yaml.safe_load(p.read_text(encoding="utf-8"))
 
@@ -48,7 +48,7 @@ def main() -> int:
     try:
         BASE.write_text(tmp.read_text(encoding="utf-8"), encoding="utf-8")
         # run report.py using subprocess
-        import subprocess  # noqa: E402
+        import subprocess
 
         result = subprocess.run(["python3", str(REPORT)], cwd=ROOT)
         if result.returncode != 0:

--- a/scripts/export_graph.py
+++ b/scripts/export_graph.py
@@ -47,7 +47,7 @@ def export_correlation_graph():
 
         # Build NetworkX graph for analysis
         try:
-            import networkx as nx  # noqa: E402
+            import networkx as nx
 
             G = nx.Graph()
 

--- a/scripts/export_stats.py
+++ b/scripts/export_stats.py
@@ -169,7 +169,7 @@ def calculate_graph_stats(db):
     )
     if use_fallback:
         try:
-            import networkx as nx  # noqa: E402
+            import networkx as nx
 
             # consider "cosine" as edge weight if present
             rows = list(
@@ -392,7 +392,7 @@ def export_correlations(db):
             set(c.get("metric", "unknown") for c in correlations)
         )
 
-    import datetime  # noqa: E402
+    import datetime
 
     metadata["generated_at"] = datetime.datetime.now().isoformat()
 
@@ -414,9 +414,9 @@ def export_correlations(db):
 def _compute_correlations_python(db):
     """Fallback: Compute correlations using Python/scipy when database view unavailable."""
     try:
-        from itertools import combinations  # noqa: E402
+        from itertools import combinations
 
-        from scipy.stats import pearsonr  # noqa: E402
+        from scipy.stats import pearsonr
     except ImportError:
         LOG.error("scipy not available for correlation computation fallback")
         return []
@@ -444,7 +444,7 @@ def _compute_correlations_python(db):
         batch_size = 100  # Limit combinations per batch
 
         # Convert embeddings to numpy arrays for efficient computation
-        import numpy as np  # noqa: E402
+        import numpy as np
 
         concept_list = []
         for row in concept_data:
@@ -669,7 +669,7 @@ def export_patterns(db):
                 set(p.get("metric", "unknown") for p in patterns)
             )
 
-        import datetime  # noqa: E402
+        import datetime
 
         metadata["generated_at"] = datetime.datetime.now().isoformat()
 
@@ -705,7 +705,7 @@ def export_temporal_patterns(db):
     - Writes exports/temporal_patterns.json
     - Validates against temporal-patterns.schema.json
     """
-    import statistics  # noqa: E402
+    import statistics
 
     patterns = []
     metadata = {
@@ -911,7 +911,7 @@ def main():
         forecasts = export_forecast(db)
 
         # Add timestamp
-        import datetime  # noqa: E402
+        import datetime
 
         now = datetime.datetime.now().isoformat()
 
@@ -922,13 +922,13 @@ def main():
         forecasts["metadata"]["generated_at"] = now
 
         # === Rule 021/022 + Rule 030: schema validation (HARD-REQUIRED) ===
-        import json  # noqa: E402
-        import sys  # noqa: E402
-        from pathlib import Path  # noqa: E402
+        import json
+        import sys
+        from pathlib import Path
 
         # Hard requirement: jsonschema must be installed
         try:
-            from jsonschema import ValidationError, validate  # noqa: E402
+            from jsonschema import ValidationError, validate
         except ImportError:
             print(
                 "[export_stats] CRITICAL: jsonschema not installed (hard requirement)",

--- a/scripts/fix/apply_repair_plan.py
+++ b/scripts/fix/apply_repair_plan.py
@@ -58,7 +58,7 @@ def main() -> int:
 
     print(f"[repair.apply] added_stub_nodes={len(added)}")
     print(f"[repair.apply] wrote {out_path.relative_to(ROOT)}")
-    print(f"[repair.apply] wrote {(EXPORTS/'graph_repaired.json').relative_to(ROOT)}")
+    print(f"[repair.apply] wrote {(EXPORTS / 'graph_repaired.json').relative_to(ROOT)}")
     print("[repair.apply] OK")
     return 0
 

--- a/scripts/fix/sanitize_missing_endpoints.py
+++ b/scripts/fix/sanitize_missing_endpoints.py
@@ -60,7 +60,7 @@ def main() -> int:
     )
     print(f"[data.sanitize] wrote {out_path.relative_to(ROOT)}")
     print(
-        f"[data.sanitize] wrote { (EXPORTS/'graph_sanitized.json').relative_to(ROOT) }"
+        f"[data.sanitize] wrote {(EXPORTS / 'graph_sanitized.json').relative_to(ROOT)}"
     )
     print("[data.sanitize] OK")
     return 0

--- a/scripts/gematria_verify.py
+++ b/scripts/gematria_verify.py
@@ -49,7 +49,7 @@ def main():
         got = gematria(c["hebrew"])
         exp = int(c["expected_value"])
         print(
-            f'{c["hebrew"]}: got={got} expected={exp}  {"OK" if got==exp else "FAIL"}'
+            f"{c['hebrew']}: got={got} expected={exp}  {'OK' if got == exp else 'FAIL'}"
         )
         if got != exp:
             bad += 1

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -458,7 +458,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
         report += f"""
 ## Enrichment Proof
 
-❌ **Error retrieving enrichment health data**: {str(e)}
+❌ **Error retrieving enrichment health data**: {e!s}
 
 """
 
@@ -487,7 +487,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
         report += f"""
 ## Concept Network Verification
 
-❌ **Error checking network health**: {str(e)}
+❌ **Error checking network health**: {e!s}
 """
 
     report += """
@@ -554,7 +554,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Relations
 
-❌ **Error retrieving relations data**: {str(e)}
+❌ **Error retrieving relations data**: {e!s}
 """
 
     # Add Confidence Gates section
@@ -576,7 +576,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Confidence Gates
 
-❌ **Error retrieving confidence gate data**: {str(e)}
+❌ **Error retrieving confidence gate data**: {e!s}
 """
 
     # Add Pattern Discovery section
@@ -615,7 +615,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Pattern Discovery
 
-❌ **Error retrieving pattern discovery data**: {str(e)}
+❌ **Error retrieving pattern discovery data**: {e!s}
 """
 
     # Add Pattern Correlation Summary (Phase 5)
@@ -623,7 +623,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
         # Try to load correlations from the export file
         correlations_path = Path("exports/graph_correlations.json")
         if correlations_path.exists():
-            import json  # noqa: E402
+            import json
 
             correlations_data = json.loads(correlations_path.read_text())
 
@@ -726,7 +726,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Pattern Correlation Summary
 
-❌ **Error retrieving correlation data**: {str(e)}
+❌ **Error retrieving correlation data**: {e!s}
 """
 
     # Phase 5-C: Add Correlation Network Analytics section
@@ -816,7 +816,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Correlation Network Analytics
 
-❌ **Error retrieving correlation network data**: {str(e)}
+❌ **Error retrieving correlation network data**: {e!s}
 """
 
     # Phase 6: Add Cross-Book Pattern Analytics section
@@ -912,7 +912,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Cross-Book Pattern Analytics
 
-❌ **Error retrieving pattern analysis data**: {str(e)}
+❌ **Error retrieving pattern analysis data**: {e!s}
 """
 
     # Phase 8: Add Temporal Analytics section
@@ -999,7 +999,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Temporal Analytics
 
-❌ **Error retrieving temporal analytics data**: {str(e)}
+❌ **Error retrieving temporal analytics data**: {e!s}
 """
 
     # Phase 8: Add Forecast Summary section
@@ -1069,7 +1069,7 @@ def generate_markdown_report(run_id: str, metrics: dict[str, Any]) -> str:
 
 ## Forecast Summary
 
-❌ **Error retrieving forecast data**: {str(e)}
+❌ **Error retrieving forecast data**: {e!s}
 """
 
     # Phase 7: Add Interactive Analytics Endpoints section
@@ -1158,7 +1158,7 @@ The API endpoints power the interactive dashboards:
 
 ## Interactive Analytics Endpoints
 
-❌ **Error retrieving endpoint information**: {str(e)}
+❌ **Error retrieving endpoint information**: {e!s}
 """
 
     report += """

--- a/scripts/goldens_status.py
+++ b/scripts/goldens_status.py
@@ -57,7 +57,7 @@ def main():
     print("-" * 96)
     for r in sorted(rows, key=lambda x: x["path"]):
         print(
-            f'{r["path"]} | {r["mtime"]} | {r["kb"]} | {r["commit"]} | {r["date"]} | {r["msg"]}'
+            f"{r['path']} | {r['mtime']} | {r['kb']} | {r['commit']} | {r['date']} | {r['msg']}"
         )
     return 0
 

--- a/scripts/mode_decider.py
+++ b/scripts/mode_decider.py
@@ -113,8 +113,9 @@ def decide_mode() -> tuple[str, list[str]]:
         return "STRICT", notes
 
     # 4) Service reachability implies we can be strict
-    api_host, api_port = os.getenv("API_HOST", "127.0.0.1"), int(
-        os.getenv("API_PORT", "8000")
+    api_host, api_port = (
+        os.getenv("API_HOST", "127.0.0.1"),
+        int(os.getenv("API_PORT", "8000")),
     )
     chat_host, chat_port = (
         os.getenv("LM_CHAT_HOST", "127.0.0.1"),

--- a/scripts/rules_guard.py
+++ b/scripts/rules_guard.py
@@ -76,7 +76,7 @@ def load_json(p: Path):
 
 def validate_json_schema(instance_path: Path, schema_path: Path):
     try:
-        from jsonschema import Draft202012Validator, validate  # noqa: E402
+        from jsonschema import Draft202012Validator, validate
 
         instance = load_json(instance_path)
         schema = load_json(schema_path)

--- a/scripts/run_book.py
+++ b/scripts/run_book.py
@@ -32,7 +32,7 @@ def _load_yaml_or_json(p: Path) -> dict[str, Any]:
     if not p.exists():
         return DEFAULT_CFG
     if p.suffix.lower() in (".yaml", ".yml"):
-        import yaml  # type: ignore  # hard-required by requirements-dev.txt  # noqa: E402
+        import yaml  # type: ignore  # hard-required by requirements-dev.txt
 
         return yaml.safe_load(p.read_text(encoding="utf-8"))
     return json.loads(p.read_text(encoding="utf-8"))
@@ -130,7 +130,7 @@ def _run_chapters(cfg: dict[str, Any], chapters: list[int], real: bool) -> None:
             encoding="utf-8",
         )
         print(
-            f"[guide] chapter {ch} {'REAL' if real else 'DRY'} done in {time.time()-t0:.2f}s"
+            f"[guide] chapter {ch} {'REAL' if real else 'DRY'} done in {time.time() - t0:.2f}s"
         )
 
 

--- a/scripts/sanity_check.py
+++ b/scripts/sanity_check.py
@@ -125,7 +125,7 @@ def test_genesis_chapter_1():
         mean_self_sim = statistics.mean(self_similarities)
 
         # Test top-5 similarities across all pairs
-        import numpy as np  # noqa: E402
+        import numpy as np
 
         X = np.vstack(embeddings)
         sim_matrix = X @ X.T  # Cosine similarities
@@ -225,7 +225,7 @@ def test_genesis_chapter_1():
 
     except Exception as e:
         print(f"   ❌ Embedding test failed: {e}")
-        import traceback  # noqa: E402
+        import traceback
 
         traceback.print_exc()
 

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -32,50 +32,50 @@ def validate_structure(records: list[dict[str, Any]]) -> list[str]:
         # Check required fields
         missing_core = [f for f in core_fields if f not in record]
         if missing_core:
-            errors.append(f"Record {i+1}: missing required fields {missing_core}")
+            errors.append(f"Record {i + 1}: missing required fields {missing_core}")
 
         # Type checks for required fields
         if "confidence" in record and not isinstance(
             record["confidence"], (int, float)
         ):
             errors.append(
-                f"Record {i+1}: confidence should be numeric, got {type(record['confidence'])}"
+                f"Record {i + 1}: confidence should be numeric, got {type(record['confidence'])}"
             )
 
         if "tokens" in record and not isinstance(record["tokens"], int):
             errors.append(
-                f"Record {i+1}: tokens should be int, got {type(record['tokens'])}"
+                f"Record {i + 1}: tokens should be int, got {type(record['tokens'])}"
             )
 
         if "insights" in record and not isinstance(record["insights"], str):
             errors.append(
-                f"Record {i+1}: insights should be str, got {type(record['insights'])}"
+                f"Record {i + 1}: insights should be str, got {type(record['insights'])}"
             )
 
         if "hebrew" in record and not isinstance(record["hebrew"], str):
             errors.append(
-                f"Record {i+1}: hebrew should be str, got {type(record['hebrew'])}"
+                f"Record {i + 1}: hebrew should be str, got {type(record['hebrew'])}"
             )
 
         if "name" in record and not isinstance(record["name"], str):
             errors.append(
-                f"Record {i+1}: name should be str, got {type(record['name'])}"
+                f"Record {i + 1}: name should be str, got {type(record['name'])}"
             )
 
         # Optional fields from collection phase (may be present)
         if "primary_verse" in record and not isinstance(record["primary_verse"], str):
             errors.append(
-                f"Record {i+1}: primary_verse should be str, got {type(record['primary_verse'])}"
+                f"Record {i + 1}: primary_verse should be str, got {type(record['primary_verse'])}"
             )
 
         if "freq" in record and not isinstance(record["freq"], int):
             errors.append(
-                f"Record {i+1}: freq should be int, got {type(record['freq'])}"
+                f"Record {i + 1}: freq should be int, got {type(record['freq'])}"
             )
 
         if "book" in record and not isinstance(record["book"], str):
             errors.append(
-                f"Record {i+1}: book should be str, got {type(record['book'])}"
+                f"Record {i + 1}: book should be str, got {type(record['book'])}"
             )
 
         if (
@@ -84,7 +84,7 @@ def validate_structure(records: list[dict[str, Any]]) -> list[str]:
             and not isinstance(record["chapter"], int)
         ):
             errors.append(
-                f"Record {i+1}: chapter should be int or null, got {type(record['chapter'])}"
+                f"Record {i + 1}: chapter should be int or null, got {type(record['chapter'])}"
             )
 
         # Validate insight length (should be substantial theological analysis)
@@ -92,14 +92,14 @@ def validate_structure(records: list[dict[str, Any]]) -> list[str]:
             word_count = len(record["insights"].split())
             if word_count < 150:
                 errors.append(
-                    f"Record {i+1}: insights too short ({word_count} words), expected 150-300 words"
+                    f"Record {i + 1}: insights too short ({word_count} words), expected 150-300 words"
                 )
 
         # Validate confidence range
         if "confidence" in record:
             conf = record["confidence"]
             if not (0.0 <= conf <= 1.0):
-                errors.append(f"Record {i+1}: confidence {conf} out of range [0,1]")
+                errors.append(f"Record {i + 1}: confidence {conf} out of range [0,1]")
 
     return errors
 

--- a/share/RULES_INDEX.md
+++ b/share/RULES_INDEX.md
@@ -44,3 +44,10 @@
 | 039 | 039-execution-contract.mdc | # id: 039_EXECUTION_CONTRACT |
 | 040 | 040-ci-triage-playbook.mdc | # id: 040_CI_TRIAGE_PLAYBOOK |
 | 041 | 041-pr-merge-policy.mdc | # id: 041_PR_MERGE_POLICY |
+| 042 | 042-formatter-single-source-of-truth.mdc | # 042 — Formatter Single Source of Truth (AlwaysApply) |
+| 043 | 043-ci-db-bootstrap.mdc | # 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply) |
+| 044 | 044-share-manifest-contract.mdc | # 044 — Share Manifest Contract (AlwaysApply) |
+| 045 | 045-rerank-blend-SSOT.mdc | # 045 — Rerank Blend is SSOT (AlwaysApply) |
+| 046 | 046-ci-hermetic-fallbacks.mdc | # 046 — Hermetic CI Fallbacks (AlwaysApply) |
+| 047 | 047-nightly-metrics-contract.mdc | # 047 — Nightly Metrics Contract (AlwaysApply) |
+| 048 | 048-agents-docs-coverage.mdc | # 048 — Agent Docs Coverage for New Modules (AlwaysApply) |

--- a/share/SSOT_MASTER_PLAN.md
+++ b/share/SSOT_MASTER_PLAN.md
@@ -131,4 +131,11 @@
 | 039 | # id: 039_EXECUTION_CONTRACT |
 | 040 | # id: 040_CI_TRIAGE_PLAYBOOK |
 | 041 | # id: 041_PR_MERGE_POLICY |
+| 042 | # 042 — Formatter Single Source of Truth (AlwaysApply) |
+| 043 | # 043 — CI DB Bootstrap & Empty-Data Handling (AlwaysApply) |
+| 044 | # 044 — Share Manifest Contract (AlwaysApply) |
+| 045 | # 045 — Rerank Blend is SSOT (AlwaysApply) |
+| 046 | # 046 — Hermetic CI Fallbacks (AlwaysApply) |
+| 047 | # 047 — Nightly Metrics Contract (AlwaysApply) |
+| 048 | # 048 — Agent Docs Coverage for New Modules (AlwaysApply) |
 <!-- RULES_TABLE_END -->

--- a/src/graph/batch_processor.py
+++ b/src/graph/batch_processor.py
@@ -11,10 +11,10 @@ from typing import Any
 from src.graph.nodes.validation import validate_noun
 
 __all__ = [
-    "BatchConfig",
-    "BatchResult",
-    "BatchProcessor",
     "BatchAbortError",
+    "BatchConfig",
+    "BatchProcessor",
+    "BatchResult",
     "process_batch",
 ]
 

--- a/src/graph/graph.py
+++ b/src/graph/graph.py
@@ -48,8 +48,8 @@ LOG = get_logger("gematria.graph")
 # Environment precedence guard - detect conflicting env sources
 def _check_env_precedence():
     """Check for environment variable conflicts between .env and .env.local."""
-    import re  # noqa: E402
-    from pathlib import Path  # noqa: E402
+    import re
+    from pathlib import Path
 
     def read_env_file(path: Path) -> dict[str, str]:
         if not path.exists():
@@ -103,7 +103,7 @@ _verify_lm_studio()
 # Postgres connectivity guard
 def _verify_postgres():
     """Verify Postgres connectivity on startup."""
-    import psycopg  # noqa: E402
+    import psycopg
 
     dsn = os.getenv("GEMATRIA_DSN")
     if not dsn:
@@ -127,7 +127,7 @@ _verify_postgres()
 # Python environment guard
 def _verify_python_env():
     """Verify we're running in the correct Python environment."""
-    import sys  # noqa: E402
+    import sys
 
     venv_expected = ".venv" in sys.executable
     if not venv_expected:
@@ -163,7 +163,7 @@ def log_qwen_health(
     try:
         db = get_gematria_rw()
         # Convert string run_id to UUID for database
-        import uuid  # noqa: E402
+        import uuid
 
         uuid_run_id = uuid.UUID(run_id)
         # Execute the insert and consume the generator to ensure it runs
@@ -354,7 +354,7 @@ def debug_connectivity() -> dict:
 
     # Test LM Studio
     try:
-        from src.services.lmstudio_client import (  # noqa: E402
+        from src.services.lmstudio_client import (
             HOST,
             QWEN_EMBEDDING_MODEL,
             QWEN_RERANKER_MODEL,
@@ -383,7 +383,7 @@ def debug_connectivity() -> dict:
 
     # Test Gematria DB
     try:
-        from src.infra.db import get_gematria_rw  # noqa: E402
+        from src.infra.db import get_gematria_rw
 
         db = get_gematria_rw()
         if db.dsn:
@@ -404,7 +404,7 @@ def debug_connectivity() -> dict:
 
     # Test Bible DB
     try:
-        from src.infra.db import get_bible_ro  # noqa: E402
+        from src.infra.db import get_bible_ro
 
         db = get_bible_ro()
         if db.dsn:
@@ -531,7 +531,7 @@ def run_hello(book: str = "Genesis", mode: str = "START") -> PipelineState:
 
 
 if __name__ == "__main__":
-    import sys  # noqa: E402
+    import sys
 
     if len(sys.argv) > 1 and sys.argv[1] == "--debug-connectivity":
         print("🔍 Connectivity Debug Report")

--- a/src/graph/patterns.py
+++ b/src/graph/patterns.py
@@ -57,7 +57,7 @@ def compute_patterns(G):
         tuple: (cluster_map, degree_centrality, betweenness_centrality, eigenvector_centrality)
     """
     # clusters using Louvain method
-    from networkx.algorithms.community import louvain_communities  # noqa: E402
+    from networkx.algorithms.community import louvain_communities
 
     comms = louvain_communities(G, weight="weight", seed=42)
     cluster_map = {}

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -15,9 +15,9 @@ except Exception:  # pragma: no cover
     HAS_DB = False  # Import optional for CI paths without DSNs
 
 __all__ = [
-    "ReadOnlyViolation",
     "BibleReadOnly",
     "GematriaRW",
+    "ReadOnlyViolation",
     "get_bible_ro",
     "get_gematria_rw",
     "sql_is_write",

--- a/src/infra/env_loader.py
+++ b/src/infra/env_loader.py
@@ -47,4 +47,4 @@ def ensure_env_loaded() -> None:
     load_env_file()
 
 
-__all__ = ["load_env_file", "ensure_env_loaded"]
+__all__ = ["ensure_env_loaded", "load_env_file"]

--- a/src/infra/metrics_core.py
+++ b/src/infra/metrics_core.py
@@ -44,7 +44,7 @@ class MetricsClient:
                 if hasattr(v, "isoformat"):  # datetime objects
                     db_row[k] = v.isoformat()
                 elif isinstance(v, dict):
-                    import json  # noqa: E402
+                    import json
 
                     db_row[k] = json.dumps(v)
                 else:
@@ -87,7 +87,7 @@ class MetricsClient:
 
 def now():
     # psycopg can take python datetime; we'll pass None where not applicable
-    import datetime as _dt  # noqa: E402
+    import datetime as _dt
 
     return _dt.datetime.now(_dt.UTC)
 

--- a/src/nodes/enrichment.py
+++ b/src/nodes/enrichment.py
@@ -126,8 +126,8 @@ def enrichment_node(state: dict) -> dict:
 
                     # enforce required keys; extract confidence if needed
                     if "confidence" not in data:
-                        import json as _json  # noqa: E402
-                        import re  # noqa: E402
+                        import json as _json
+                        import re
 
                         m = re.search(
                             r"\bconfidence(?:\s+score)?\s*(?:is|:)?\s*(0?\.\d+|1(?:\.0+)?)\b",
@@ -175,9 +175,10 @@ def enrichment_node(state: dict) -> dict:
                     # Persist to database (optional for testing)
                     if GEMATRIA_DSN:
                         try:
-                            with psycopg.connect(
-                                GEMATRIA_DSN
-                            ) as conn, conn.cursor() as cur:
+                            with (
+                                psycopg.connect(GEMATRIA_DSN) as conn,
+                                conn.cursor() as cur,
+                            ):
                                 cur.execute(
                                     """INSERT INTO ai_enrichment_log
                                        (run_id,node,noun_id,model_name,confidence_model,

--- a/src/nodes/network_aggregator.py
+++ b/src/nodes/network_aggregator.py
@@ -31,8 +31,8 @@ except ImportError:
         pass
 
 
-from src.infra.structured_logger import get_logger, log_json  # noqa: E402
-from src.services.lmstudio_client import get_lmstudio_client  # noqa: E402
+from src.infra.structured_logger import get_logger, log_json
+from src.services.lmstudio_client import get_lmstudio_client
 
 LOG = get_logger("gemantria.network_aggregator")
 
@@ -62,7 +62,7 @@ def _l2_normalize(vec: list[float]) -> list[float]:
 
 def _knn_pairs(vecs, ids, k):
     """Naive cosine KNN for small batches with improved similarity computation."""
-    import numpy as np  # noqa: E402
+    import numpy as np
 
     X = np.vstack(vecs)  # L2-normalized already
     sims = X @ X.T  # Cosine similarity (vectors are L2 normalized)
@@ -124,7 +124,7 @@ def build_relations(db, embeddings_batch, enriched_nouns=None):
         raise
 
     kept = []
-    from src.services.rerank_via_embeddings import (  # noqa: E402
+    from src.services.rerank_via_embeddings import (
         rerank_via_embeddings as rerank_pairs,
     )
 
@@ -150,7 +150,7 @@ def build_relations(db, embeddings_batch, enriched_nouns=None):
         raise
 
     # Rerank ALL pairs in batches
-    import os  # noqa: E402
+    import os
 
     # Weight cosine vs rerank via env knob (default: lean on cosine)
     EDGE_ALPHA = float(os.getenv("EDGE_ALPHA", "0.70"))  # 0..1
@@ -284,7 +284,7 @@ def network_aggregator_node(state: dict[str, Any]) -> dict[str, Any]:
 
     except Exception as e:
         log_json(LOG, 40, "network_aggregation_failed", error=str(e))
-        raise NetworkAggregationError(f"Network aggregation failed: {str(e)}") from e
+        raise NetworkAggregationError(f"Network aggregation failed: {e!s}") from e
 
 
 def _generate_and_store_embeddings(
@@ -400,7 +400,7 @@ def _build_document_string(noun: dict[str, Any]) -> str:
         primary_verse = f"{book} (reference)"
 
     # Build highly differentiated semantic document with unique identifiers
-    import uuid  # noqa: E402
+    import uuid
 
     unique_id = str(uuid.uuid4())[:8]  # Short unique identifier
 
@@ -586,7 +586,7 @@ def _get_knn_neighbors(
 
 def _cosine_similarity(vec1: list[float], vec2: list[float]) -> float:
     """Compute cosine similarity between two vectors."""
-    import math  # noqa: E402
+    import math
 
     if len(vec1) != len(vec2):
         raise ValueError("Vectors must have same length")

--- a/src/obs/prom_exporter.py
+++ b/src/obs/prom_exporter.py
@@ -78,6 +78,6 @@ def metrics():
 
 # Optional: local runner
 if __name__ == "__main__" and PROM_EXPORTER_ENABLED:
-    import uvicorn  # noqa: E402
+    import uvicorn
 
     uvicorn.run(app, host="0.0.0.0", port=PROM_EXPORTER_PORT)

--- a/src/services/api_server.py
+++ b/src/services/api_server.py
@@ -401,7 +401,7 @@ async def get_temporal_patterns(
     except Exception as e:
         LOG.error(f"Error in temporal patterns endpoint: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Internal server error: {str(e)}"
+            status_code=500, detail=f"Internal server error: {e!s}"
         ) from e
 
 
@@ -456,12 +456,12 @@ async def get_forecasts(
     except Exception as e:
         LOG.error(f"Error in forecast endpoint: {e}")
         raise HTTPException(
-            status_code=500, detail=f"Internal server error: {str(e)}"
+            status_code=500, detail=f"Internal server error: {e!s}"
         ) from e
 
 
 if __name__ == "__main__":
-    import uvicorn  # noqa: E402
+    import uvicorn
 
     # Default to port 8000, but allow override
     port = int(os.getenv("API_PORT", "8000"))

--- a/src/services/lmstudio_client.py
+++ b/src/services/lmstudio_client.py
@@ -168,7 +168,7 @@ def assert_qwen_live(required_models: list[str]) -> QwenHealth:
         )
 
     except requests.exceptions.ConnectionError as e:
-        reason = f"Cannot connect to LM Studio at {HOST}. Is LM Studio server running? Error: {str(e)}"
+        reason = f"Cannot connect to LM Studio at {HOST}. Is LM Studio server running? Error: {e!s}"
         return QwenHealth(
             ok=False,
             reason=reason,
@@ -200,7 +200,9 @@ def assert_qwen_live(required_models: list[str]) -> QwenHealth:
             lat_ms_rerank=None,
         )
     except requests.RequestException as e:
-        reason = f"LM Studio network error: {str(e)}. Check firewall and network connectivity."
+        reason = (
+            f"LM Studio network error: {e!s}. Check firewall and network connectivity."
+        )
         return QwenHealth(
             ok=False,
             reason=reason,
@@ -210,7 +212,7 @@ def assert_qwen_live(required_models: list[str]) -> QwenHealth:
         )
     except Exception as e:
         reason = (
-            f"Unexpected health check failure: {str(e)}. Check LM Studio configuration."
+            f"Unexpected health check failure: {e!s}. Check LM Studio configuration."
         )
         return QwenHealth(
             ok=False,
@@ -277,7 +279,7 @@ class LMStudioClient:
                     )
                 raise QwenUnavailableError(error_msg) from e
             except Exception as e:
-                error_msg = f"Unexpected LM Studio error: {str(e)}"
+                error_msg = f"Unexpected LM Studio error: {e!s}"
                 if attempt < RETRY_ATTEMPTS - 1:
                     print(f"Warning: {error_msg}. Retrying in {RETRY_DELAY}s...")
                     time.sleep(RETRY_DELAY)
@@ -308,7 +310,7 @@ class LMStudioClient:
             .strip()
         )
         # Extract just the numeric part if the model returns extra text
-        import re  # noqa: E402
+        import re
 
         match = re.search(r"([0-9]*\.?[0-9]+)", content)
         if match:
@@ -334,7 +336,7 @@ class LMStudioClient:
         """
         if _is_mock_mode() or not _get_bool_env("USE_QWEN_EMBEDDINGS", "true"):
             # Return mock embeddings for testing or when disabled
-            import random  # noqa: E402
+            import random
 
             result = []
             for text in texts:
@@ -375,7 +377,7 @@ class LMStudioClient:
                     # Hard fail - no mock fallback in production
                     if _get_bool_env("ALLOW_MOCKS_FOR_TESTS", "false"):
                         # Test-only bypass for unit tests
-                        import random  # noqa: E402
+                        import random
 
                         result = []
                         for text in texts:
@@ -389,7 +391,7 @@ class LMStudioClient:
                     else:
                         # Production mode - hard fail
                         raise QwenUnavailableError(
-                            f"LM Studio embeddings failed after {RETRY_ATTEMPTS} attempts: {str(e)}"
+                            f"LM Studio embeddings failed after {RETRY_ATTEMPTS} attempts: {e!s}"
                         )
 
     def rerank(
@@ -411,7 +413,7 @@ class LMStudioClient:
         """
         if _is_mock_mode():
             # Return mock reranking scores for testing
-            import random  # noqa: E402
+            import random
 
             random.seed(hash(query) % 10000)
             return [random.uniform(0.1, 0.9) for _ in candidates]
@@ -521,7 +523,7 @@ def rerank_pairs(pairs, name_map=None):
     name_map: optional dict mapping concept_ids to names
     Returns list of scores [0..1] indicating similarity strength.
     """
-    from src.infra.db import get_gematria_rw  # noqa: E402
+    from src.infra.db import get_gematria_rw
 
     texts = []
     if name_map:
@@ -617,7 +619,7 @@ def chat_completion(
                         break
                     else:
                         raise QwenUnavailableError(
-                            f"LM Studio chat completion failed after {RETRY_ATTEMPTS} attempts: {str(e)}"
+                            f"LM Studio chat completion failed after {RETRY_ATTEMPTS} attempts: {e!s}"
                         )
 
     return results
@@ -651,7 +653,7 @@ def safe_json_parse(text: str, required_keys: list[str]) -> dict:
         data = json.loads(text)
     except Exception as e:
         raise ValueError(
-            f"Failed to parse JSON response: {str(e)}. Raw text: {text[:200]}..."
+            f"Failed to parse JSON response: {e!s}. Raw text: {text[:200]}..."
         )
 
     # Validate required keys

--- a/test_bi_encoder_rerank.py
+++ b/test_bi_encoder_rerank.py
@@ -63,9 +63,9 @@ def test_bi_encoder_rerank():
         mock_requests.post.side_effect = [mock_resp_a, mock_resp_b]
 
         # Import and test the rerank function
-        from src.services.rerank_via_embeddings import (  # noqa: E402
+        from src.services.rerank_via_embeddings import (
             rerank_via_embeddings,
-        )  # noqa: E402
+        )
 
         test_pairs = [(0, 1), (0, 2), (1, 2)]
         test_names = {0: "אלהים", 1: "ברא", 2: "שמים"}
@@ -97,7 +97,7 @@ def test_bi_encoder_rerank():
     # Test 2: Normalization
     print("\n2. Testing text normalization...")
 
-    from src.services.rerank_via_embeddings import _norm  # noqa: E402
+    from src.services.rerank_via_embeddings import _norm
 
     test_cases = [
         ("hello world", "hello world"),
@@ -134,8 +134,8 @@ def test_bi_encoder_rerank():
     print("\n4. Testing import and interface compatibility...")
 
     # Test that the new rerank function can be imported as the old name
-    from src.services.rerank_via_embeddings import (  # noqa: E402
-        rerank_via_embeddings as rerank_pairs,  # noqa: E402
+    from src.services.rerank_via_embeddings import (
+        rerank_via_embeddings as rerank_pairs,
     )
 
     # Test with simple mock

--- a/tests/contract/test_batch_semantics.py
+++ b/tests/contract/test_batch_semantics.py
@@ -44,7 +44,7 @@ def test_batch_size_enforcement_strict_mode(cleanup_review_file):
     assert len(lines) == 2  # One line per noun
 
     # Check content structure
-    import json  # noqa: E402
+    import json
 
     for line in lines:
         entry = json.loads(line)

--- a/tests/integration/test_api_temporal_forecast.py
+++ b/tests/integration/test_api_temporal_forecast.py
@@ -64,7 +64,7 @@ def test_api_temporal_and_forecast_smoke(tmp_path, monkeypatch):
     proc = subprocess.Popen(["python", "-m", "src.services.api_server"])
     try:
         time.sleep(1.5)
-        import urllib.request  # noqa: E402
+        import urllib.request
 
         with urllib.request.urlopen(
             "http://127.0.0.1:8000/api/v1/temporal?unit=chapter&window=5"

--- a/tests/integration/test_graph_batch_integration.py
+++ b/tests/integration/test_graph_batch_integration.py
@@ -25,7 +25,7 @@ def test_graph_pipeline_structure():
     assert hasattr(graph, "invoke")  # Should be a compiled graph
 
     # Check that checkpointer was set during creation
-    from src.infra.checkpointer import get_checkpointer  # noqa: E402
+    from src.infra.checkpointer import get_checkpointer
 
     checkpointer = get_checkpointer()
     assert checkpointer is not None
@@ -118,7 +118,7 @@ def test_graph_state_preservation():
 
 def test_backward_compatibility():
     """Test that run_hello still works for backward compatibility."""
-    from src.graph.graph import run_hello  # noqa: E402
+    from src.graph.graph import run_hello
 
     result = run_hello("Exodus", "TEST")
 

--- a/tests/integration/test_metrics_db_roundtrip.py
+++ b/tests/integration/test_metrics_db_roundtrip.py
@@ -10,7 +10,7 @@ from src.infra.metrics_core import MetricsClient
 def test_metrics_insert_roundtrip():
     dsn = os.getenv("GEMATRIA_DSN")
     if not dsn:
-        import pytest  # noqa: E402
+        import pytest
 
         pytest.skip("no DB configured")
     mc = MetricsClient(dsn)

--- a/tests/integration/test_network_aggregator_integration.py
+++ b/tests/integration/test_network_aggregator_integration.py
@@ -179,7 +179,7 @@ class TestNetworkAggregatorIntegration(unittest.TestCase):
                 self.assertEqual(len(embedding), 1024)  # VECTOR_DIM
 
                 # Verify it's a numpy array of float32 values
-                import numpy as np  # noqa: E402
+                import numpy as np
 
                 self.assertIsInstance(embedding, np.ndarray)
                 self.assertEqual(embedding.dtype, np.float32)
@@ -365,7 +365,7 @@ class TestNetworkAggregatorIntegration(unittest.TestCase):
                 embedding2 = cur.fetchone()[0]
 
                 # Embeddings should be identical (deterministic mock)
-                import numpy as np  # noqa: E402
+                import numpy as np
 
                 self.assertTrue(np.array_equal(embedding1, embedding2))
 

--- a/tests/integration/test_relations_and_patterns.py
+++ b/tests/integration/test_relations_and_patterns.py
@@ -152,8 +152,8 @@ class TestRelationsAndPatternsIntegration:
         """Test that analyze_graph.py script can be executed."""
         # This is a basic smoke test - the script should not crash
         # In a real test environment, we'd run the script and check results
-        import subprocess  # noqa: E402
-        import sys  # noqa: E402
+        import subprocess
+        import sys
 
         try:
             result = subprocess.run(
@@ -173,8 +173,8 @@ class TestRelationsAndPatternsIntegration:
 
     def test_export_script_execution(self, db_connection):
         """Test that export_graph.py script can be executed."""
-        import subprocess  # noqa: E402
-        import sys  # noqa: E402
+        import subprocess
+        import sys
 
         try:
             result = subprocess.run(

--- a/tests/unit/test_confidence_gates.py
+++ b/tests/unit/test_confidence_gates.py
@@ -81,13 +81,13 @@ class TestConfidenceGates:
     def test_custom_thresholds(self):
         """Test with custom environment thresholds."""
         # Reload module to pick up new env vars
-        import importlib  # noqa: E402
+        import importlib
 
-        import src.nodes.enrichment  # noqa: E402
+        import src.nodes.enrichment
 
         importlib.reload(src.nodes.enrichment)
-        from src.nodes.enrichment import HARD as new_hard  # noqa: E402
-        from src.nodes.enrichment import SOFT as new_soft  # noqa: E402
+        from src.nodes.enrichment import HARD as new_hard
+        from src.nodes.enrichment import SOFT as new_soft
 
         assert new_soft == 0.85
         assert new_hard == 0.92

--- a/tests/unit/test_network_aggregator.py
+++ b/tests/unit/test_network_aggregator.py
@@ -182,7 +182,7 @@ class TestEmbeddingFunctionality(unittest.TestCase):
 
     def test_vector_normalization(self):
         """Test that vectors are properly L2 normalized."""
-        import math  # noqa: E402
+        import math
 
         # Test with a non-normalized vector
         vec = [3.0, 4.0]  # Should normalize to [0.6, 0.8]
@@ -273,7 +273,7 @@ class TestEdgeStrengthCalculation(unittest.TestCase):
     def test_edge_classification_strong(self):
         """Test edge classification for strong relationships (≥0.90)."""
         # Import the constants
-        import os  # noqa: E402
+        import os
 
         os.environ["EDGE_STRONG"] = "0.90"
 
@@ -284,13 +284,15 @@ class TestEdgeStrengthCalculation(unittest.TestCase):
         relation_type = (
             "strong"
             if edge_strength >= 0.90
-            else "weak" if edge_strength >= 0.75 else None
+            else "weak"
+            if edge_strength >= 0.75
+            else None
         )
         self.assertEqual(relation_type, "strong")
 
     def test_edge_classification_weak(self):
         """Test edge classification for weak relationships (≥0.75, <0.90)."""
-        import os  # noqa: E402
+        import os
 
         os.environ["EDGE_STRONG"] = "0.90"
         os.environ["EDGE_WEAK"] = "0.75"
@@ -310,7 +312,7 @@ class TestEdgeStrengthCalculation(unittest.TestCase):
 
     def test_edge_classification_filtered(self):
         """Test edge classification for filtered relationships (<0.75)."""
-        import os  # noqa: E402
+        import os
 
         os.environ["EDGE_WEAK"] = "0.75"
 
@@ -332,7 +334,7 @@ class TestRerankScoreMapping(unittest.TestCase):
 
     def test_logprob_score_calculation(self):
         """Test score calculation from log probabilities using sigmoid."""
-        import math  # noqa: E402
+        import math
 
         # Mock logprobs data
         logprobs = {

--- a/tools/genesis_autopilot.py
+++ b/tools/genesis_autopilot.py
@@ -197,7 +197,7 @@ def audit_phase(phase):
     expected = MODELS[phase]
     if expected not in ids:
         print(
-            f"[FAIL] :{port} expected model '{expected}' not found. Available: {ids}",  # noqa: E501
+            f"[FAIL] :{port} expected model '{expected}' not found. Available: {ids}",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
Adds seven AlwaysApply rules in .cursor/rules (042–048): formatter SSoT, CI DB bootstrap, share contract, rerank SSOT, hermetic CI, nightly metrics, agent docs coverage. Rebuilt RULES_INDEX and share mirrors via rules_audit + share.sync. Acceptance: ops.verify OK; rules audit OK; share sync OK.