### PR TITLE
ci(069): render coverage badge as exact percentage (two decimals)

### DIFF
--- a/.github/workflows/quality-badges.yml
+++ b/.github/workflows/quality-badges.yml
@@ -54,7 +54,8 @@ jobs:
         run: |
           python scripts/eval/gen_badge.py "MyPy Errors"  "${{ steps.vals.outputs.mypy }}"  "#007ec6" > share/eval/badges/mypy.svg
           python scripts/eval/gen_badge.py "Ruff Issues"  "${{ steps.vals.outputs.ruff }}"  "#5c53ff" > share/eval/badges/ruff.svg
-          python scripts/eval/gen_badge.py "Coverage %"   "${{ steps.vals.outputs.cover }}" "#4c1"    > share/eval/badges/coverage.svg
+          # Show exact percent with two decimals inside the value: e.g., "Coverage 87.32%"
+          python scripts/eval/gen_badge.py "Coverage"     "${{ steps.vals.outputs.cover }}%" "#4c1"    > share/eval/badges/coverage.svg
           python scripts/eval/gen_badge.py "Graph Anoms" "${{ steps.vals.outputs.graph }}" "#d97706" > share/eval/badges/graph.svg
 
       - name: Upload badges as artifact


### PR DESCRIPTION
**Goal**: Render coverage badge as exact percentage with two decimals

**Changes**: Move `%` symbol from label to value in quality-badges.yml workflow

**Before**: `Coverage % 87.32`  
**After**: `Coverage 87.32%`

**Tests**: ops.verify passes ✅  
**Artifact-first**: No share manifest changes needed

Surgical change affecting only the badge rendering logic.