### PR TITLE
[RESCUE] ci/coverage-badge-069

### DIFF
--- a/.github/workflows/quality-badges.yml
+++ b/.github/workflows/quality-badges.yml
@@ -54,7 +54,8 @@ jobs:
         run: |
           python scripts/eval/gen_badge.py "MyPy Errors"  "${{ steps.vals.outputs.mypy }}"  "#007ec6" > share/eval/badges/mypy.svg
           python scripts/eval/gen_badge.py "Ruff Issues"  "${{ steps.vals.outputs.ruff }}"  "#5c53ff" > share/eval/badges/ruff.svg
-          python scripts/eval/gen_badge.py "Coverage %"   "${{ steps.vals.outputs.cover }}" "#4c1"    > share/eval/badges/coverage.svg
+          # Show exact percent with two decimals inside the value: e.g., "Coverage 87.32%"
+          python scripts/eval/gen_badge.py "Coverage"     "${{ steps.vals.outputs.cover }}%" "#4c1"    > share/eval/badges/coverage.svg
           python scripts/eval/gen_badge.py "Graph Anoms" "${{ steps.vals.outputs.graph }}" "#d97706" > share/eval/badges/graph.svg
 
       - name: Upload badges as artifact


### PR DESCRIPTION
Automated rescue PR opened to re-trigger CI under Rule 049 governance.\n\nBranch: ci/coverage-badge-069\nGenerated: 2025-10-29 01:05:20 UTC

## Summary by Sourcery

CI:
- Change the coverage badge label from "Coverage %" to "Coverage" and append '%' to the output value for two-decimal display