### PR TITLE
[RESCUE] feature/phase8-badges-release-notes-015

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,3 +384,34 @@ eval.apply.remediation:
 
 ci.eval.apply.remediation:
 	@python3 scripts/eval/apply_remediation.py
+
+.PHONY: eval.badges ci.eval.badges eval.release_notes ci.eval.release_notes eval.package ci.eval.package
+
+eval.badges:
+	@python3 scripts/eval/build_badges.py
+
+ci.eval.badges:
+	@python3 scripts/eval/build_badges.py
+
+eval.release_notes:
+	@python3 scripts/eval/build_release_notes.py
+
+ci.eval.release_notes:
+	@python3 scripts/eval/build_release_notes.py
+
+# One-shot local packaging: snapshot → html → bundle → badges → release_notes
+eval.package:
+	@$(MAKE) eval.snapshot
+	@$(MAKE) eval.html
+	@$(MAKE) eval.bundle
+	@$(MAKE) eval.badges
+	@$(MAKE) eval.release_notes
+	@echo "[eval.package] OK"
+
+ci.eval.package:
+	@$(MAKE) eval.snapshot
+	@$(MAKE) eval.html
+	@$(MAKE) eval.bundle
+	@$(MAKE) eval.badges
+	@$(MAKE) eval.release_notes
+	@echo "[eval.package] OK"

--- a/docs/PHASE8_EVAL.md
+++ b/docs/PHASE8_EVAL.md
@@ -340,3 +340,36 @@ Artifact:
 **Current automated fixes:**
 - Pipeline regeneration (`make go`) for missing files
 - Future: Additional automated fixes as they're identified and validated
+
+### Badges (local-only)
+Run:
+```bash
+make eval.badges
+```
+
+Artifacts:
+
+* `share/eval/badges/report_status.svg`
+* `share/eval/badges/strict_gate.svg`
+
+### Release notes (local-only)
+
+Run:
+
+```bash
+make eval.release_notes
+```
+
+Artifact:
+
+* `share/eval/release_notes.md` — curated summary from report/history/delta/id-stability/provenance/policy_diff.
+
+### Package (local-only)
+
+Run:
+
+```bash
+make eval.package
+```
+
+Runs: snapshot → html → bundle → badges → release_notes, then prints `[eval.package] OK`.

--- a/scripts/eval/build_badges.py
+++ b/scripts/eval/build_badges.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVAL = ROOT / "share" / "eval"
+BADGES = EVAL / "badges"
+REPORT_JSON = EVAL / "report.json"
+
+
+def _badge(label: str, value: str, color: str) -> str:
+    text = f"{label}: {value}"
+    w = 90 + 8 * max(0, len(text) - 8)
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20" role="img" aria-label="{text}">
+  <linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+  <rect rx="3" width="{w}" height="20" fill="#555"/>
+  <rect rx="3" x="55" width="{w-55}" height="20" fill="{color}"/>
+  <path fill="{color}" d="M55 0h4v20h-4z"/>
+  <rect rx="3" width="{w}" height="20" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="28" y="14">{label}</text>
+    <text x="{(55 + (w-55)/2):.0f}" y="14">{value}</text>
+  </g>
+</svg>"""
+
+
+def main() -> int:
+    print("[eval.badges] starting")
+    BADGES.mkdir(parents=True, exist_ok=True)
+    ok = 0
+    fail = 0
+    if REPORT_JSON.exists():
+        doc = json.loads(REPORT_JSON.read_text(encoding="utf-8"))
+        s = doc.get("summary", {})
+        ok = int(s.get("ok_count", 0))
+        fail = int(s.get("fail_count", 0))
+    status = "OK" if fail == 0 else "FAIL"
+    color = "#4c1" if fail == 0 else "#e05d44"
+    (BADGES / "report_status.svg").write_text(
+        _badge("report", status, color), encoding="utf-8"
+    )
+    (BADGES / "strict_gate.svg").write_text(
+        _badge("strict", status, color), encoding="utf-8"
+    )
+    print(f"[eval.badges] wrote {BADGES.relative_to(ROOT)}/report_status.svg")
+    print(f"[eval.badges] wrote {BADGES.relative_to(ROOT)}/strict_gate.svg")
+    print("[eval.badges] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/build_release_notes.py
+++ b/scripts/eval/build_release_notes.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVAL = ROOT / "share" / "eval"
+OUT = EVAL / "release_notes.md"
+
+
+def _load(p: pathlib.Path) -> dict[str, Any] | None:
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else None
+
+
+def main() -> int:
+    print("[eval.release_notes] starting")
+    EVAL.mkdir(parents=True, exist_ok=True)
+    report = _load(EVAL / "report.json") or {}
+    hist = _load(EVAL / "history.json") or {}
+    delta = _load(EVAL / "delta.json") or {}
+    idst = _load(EVAL / "id_stability.json") or {}
+    prov = _load(EVAL / "provenance.json") or {}
+    policy = (
+        (EVAL / "policy_diff.md").read_text(encoding="utf-8")
+        if (EVAL / "policy_diff.md").exists()
+        else ""
+    )
+    s = report.get("summary", {})
+    ok, fail, tasks = (
+        s.get("ok_count", 0),
+        s.get("fail_count", 0),
+        s.get("task_count", 0),
+    )
+    hist_ok = (hist.get("summary", {}) or {}).get("ok_all", True)
+    hist_n = (hist.get("summary", {}) or {}).get("series_n", 0)
+    isb = idst.get("summary", {}) or {}
+    jaccard = isb.get("jaccard")
+    id_added = isb.get("added_ids")
+    id_removed = isb.get("removed_ids")
+    dsum = delta.get("summary", {}) or {}
+    d_has_prev = dsum.get("has_previous")
+    d_ok = dsum.get("ok", True)
+
+    lines = []
+    lines.append("# Gemantria – Release Notes (Local Eval)\n")
+    lines.append(f"*generated:* {int(time.time())}")
+    if prov:
+        head = prov.get("repo", {}).get("git_head")
+        branch = prov.get("repo", {}).get("git_branch")
+        lines.append(f"*git:* `{head}` on `{branch}`")
+    lines.append("\n## Summary")
+    lines.append(f"- Manifest tasks: **{ok}/{tasks} OK**, **{fail} FAIL**")
+    lines.append(f"- History: series={hist_n} • ok_all={'✅' if hist_ok else '❌'}")
+    if jaccard is not None:
+        lines.append(
+            f"- ID stability: jaccard={jaccard} • added={id_added} • removed={id_removed}"
+        )
+    if d_has_prev is not None:
+        lines.append(
+            f"- Delta: has_previous={d_has_prev} • ok={'✅' if d_ok else '❌'}\n"
+        )
+    lines.append("## Policy Delta (strict vs dev)")
+    lines.append(policy.strip() or "_No policy_diff.md present._\n")
+    lines.append("## Provenance (excerpt)")
+    if prov:
+        pv = {
+            "git_head": prov.get("repo", {}).get("git_head"),
+            "manifest_version": prov.get("manifest_version"),
+            "thresholds_version": prov.get("thresholds_version"),
+            "exports_count": (prov.get("exports", {}) or {}).get("count"),
+        }
+        lines.append("```json")
+        import json as _json
+
+        lines.append(_json.dumps(pv, indent=2, sort_keys=True))
+        lines.append("```")
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[eval.release_notes] wrote {OUT.relative_to(ROOT)}")
+    print("[eval.release_notes] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Automated rescue PR opened to re-trigger CI under Rule 049 governance.\n\nBranch: feature/phase8-badges-release-notes-015\nGenerated: 2025-10-29 01:06:03 UTC

## Summary by Sourcery

Introduce local evaluation tooling by adding badge and release note generation scripts, corresponding Makefile targets (with CI variants), and documentation updates to enable a one-shot package evaluation workflow.

New Features:
- Add Python scripts to generate evaluation badges and release notes
- Introduce Makefile targets eval.badges, eval.release_notes, and eval.package with CI equivalents

Enhancements:
- Provide a one-shot local package evaluation workflow that runs snapshot, HTML, bundle, badges, and release notes

Documentation:
- Update PHASE8_EVAL.md with instructions for badge, release notes, and local package evaluation workflows