### PR TITLE
Cursor 2.0 baseline: ignore files + AGENTS.md editor guidance

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,9 +1,43 @@
-# Index control - only .env should be ignored, .env.example is accessible
-.env
-!/.env.example
-data/
-**/__pycache__/
-**/*.pyc
-!/.env.local
-!/.env
-!/.env.backup
+# Build artifacts and mirrors
+
+share/**
+
+_artifacts/**
+
+# Environments / vendors / caches
+
+.venv/**
+
+env/**
+
+venv/**
+
+node_modules/**
+
+**/.pytest_cache/**
+
+**/__pycache__/**
+
+# Heavy or binary data (agents shouldn't ingest)
+
+**/*.parquet
+
+**/*.feather
+
+**/*.csv
+
+**/*.npz
+
+**/*.npy
+
+dumps/**
+
+data/**
+
+# VCS and editor internals
+
+.git/**
+
+.vscode/**
+
+.idea/**

--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,23 @@
+# Mirror of .cursorignore, but *only* for indexing scope
+
+share/**
+
+_artifacts/**
+
+node_modules/**
+
+.venv/**
+
+**/.pytest_cache/**
+
+**/__pycache__/**
+
+.git/**
+
+**/*.parquet
+
+**/*.feather
+
+**/*.csv
+
+dumps/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,3 +155,31 @@ Hermetic validation enforces `edge_strength = α*cosine + (1-α)*rerank_score` c
 | 048 | # --- |
 | 049 | # id: 049_GPT5_CONTRACT_V5_2 |
 <!-- RULES_INVENTORY_END -->
+
+---
+
+## Editor Baseline (Cursor 2.0)
+
+**Purpose:** speed up surgical PR work while preserving SSOT governance.
+
+### Settings (per developer)
+
+- **Multi-Agents:** **Enabled**; set parallel agents to **4–8** as hardware allows. Cursor isolates agents via **git worktrees / remote machines** to avoid file conflicts. :contentReference[oaicite:1]{index=1}
+
+- **Models:** **Plan with your top reasoner**; **Build with *Composer*** (Cursor's agentic coding model, ~**4× faster**, most turns **<30s**). :contentReference[oaicite:2]{index=2}
+
+- **Browser for Agent:** Allowed **in-editor** for research/design only (CI remains hermetic). Browser is **GA** in 2.0 and can forward DOM to the agent. :contentReference[oaicite:3]{index=3}
+
+- **Sandboxed Terminals:** Prefer sandboxed agent shells (no network) where supported; keep our CI "no network" invariant regardless. :contentReference[oaicite:4]{index=4}
+
+### Team Rules / Commands
+
+- SSOT remains in-repo (`.cursor/rules/*.mdc`). Optional dashboard **Team Rules/Commands** may drift or fail to sync; if used, generate them **from** the repo and treat dashboard as a mirror only. :contentReference[oaicite:5]{index=5}
+
+### Guardrails we keep
+
+- **No outbound network in CI.** Use hermetic validators and artifacts-first routing.
+
+- **No `share/**` writes in CI.** Route CI outputs to `_artifacts/**`.
+
+- **Ruff-format is the single formatter.** Workflows should run `ruff format --check .` and `ruff check .`.


### PR DESCRIPTION
Adopts Cursor 2.0 safely: Composer for builds, Multi-Agents with worktrees, Browser GA for research only, sandboxed shells where supported. Adds .cursorignore/.cursorindexingignore and documents the settings/guardrails. Governance remains repo-SSOT.