### PR TITLE
feat(P6-cli): reuse-first Typer CLI + quick-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,22 @@ ci.quality.smoke: ## CI quality smoke (no DB, no network)
 	  MOCK_AI=1 SKIP_DB=1 PIPELINE_SEED=4242 \
 	  bash scripts/quality/smoke.sh
 
+# ---------- CLI (Phase-6: reuse-first Typer wrapper) ----------
+
+.PHONY: cli.help
+cli.help: ## Show CLI usage (reuse-first Typer CLI)
+	@python3 scripts/cli/gemantria_cli.py --help || true
+
+.PHONY: cli.quickstart
+cli.quickstart: ## 5-minute local quick-start (hermetic)
+	@python3 scripts/cli/gemantria_cli.py quickstart
+
+.PHONY: ci.cli.smoke
+ci.cli.smoke: ## CLI smoke (hermetic)
+	@python3 scripts/cli/gemantria_cli.py verify
+	@MOCK_AI=1 SKIP_DB=1 EDGE_STRONG=${EDGE_STRONG:-0.90} EDGE_WEAK=${EDGE_WEAK:-0.75} \
+	  python3 scripts/cli/gemantria_cli.py pipeline
+
 # ---------- Governance & Policy Gates ----------
 
 .PHONY: eval.report ci.eval.report

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ ruff~=0.6
 mypy~=1.11
 rdflib~=7.0
 jsonschema~=4.23
+typer~=0.12

--- a/scripts/cli/gemantria_cli.py
+++ b/scripts/cli/gemantria_cli.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+
+Gemantria CLI (reuse-first, Phase-6)
+
+Thin Typer wrapper that proxies to existing Make targets and scripts.
+
+No new logic; no network; hermetic-friendly.
+
+"""
+
+from __future__ import annotations
+
+import subprocess, os, sys
+
+import typer
+
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def _run(cmd: str) -> int:
+    return subprocess.call(cmd, shell=True, env=os.environ.copy())
+
+
+@app.command(help="Show active thresholds and key envs.")
+def env():
+    print("EDGE_STRONG=", os.getenv("EDGE_STRONG", "0.90"))
+
+    print("EDGE_WEAK=", os.getenv("EDGE_WEAK", "0.75"))
+
+    print("CANDIDATE_POLICY=", os.getenv("CANDIDATE_POLICY", "cache"))
+
+
+@app.command(help="Run governance gates (ruff + rules_guard).")
+def verify():
+    sys.exit(_run("make -s ops.verify"))
+
+
+@app.command(help="DB migrations (tolerates empty/missing DB if CI helper used).")
+def db_migrate():
+    sys.exit(_run("make -s db.migrate || make -s ci.db.tolerate.empty"))
+
+
+@app.command(help="Pipeline smoke (reuse-first; hermetic).")
+def pipeline():
+    sys.exit(_run("make -s ci.pipeline.smoke"))
+
+
+@app.command(help="Exports + badges (reuse-first; empty-DB tolerant).")
+def exports():
+    code = _run("make -s ci.exports.smoke && make -s ci.exports.validate && make -s ci.badges")
+
+    sys.exit(code)
+
+
+@app.command(help="Web UI smoke (adapter + existing viewer build if present).")
+def webui():
+    sys.exit(_run("make -s ci.webui.smoke"))
+
+
+@app.command(help="Quality/reranker smoke (reuse-first).")
+def quality():
+    sys.exit(_run("make -s ci.quality.smoke && make -s quality.show.thresholds"))
+
+
+@app.command(help="5-minute local quick-start (hermetic).")
+def quickstart():
+    cmds = [
+        "ruff format --check . && ruff check .",
+        "make -s ops.verify",
+        "make -s ci.pipeline.smoke",
+        "make -s ci.exports.smoke",
+        "make -s ci.webui.smoke",
+        "make -s ci.quality.smoke",
+    ]
+
+    for c in cmds:
+        print("[quickstart]>", c)
+
+        rc = _run(c)
+
+        if rc != 0:
+            print(f"[quickstart] step failed rc={rc}")
+
+            sys.exit(rc)
+
+    print("[quickstart] complete ✅")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
Thin CLI wrapper that calls existing Make/scripts; hermetic quick-start + CI smoke.

**Changes:**
- Add typer~=0.12 to requirements.txt for CLI framework
- Create scripts/cli/gemantria_cli.py with thin Typer wrapper
- Proxy existing Make targets (no new logic, reuse-first)
- Add cli.help, cli.quickstart, ci.cli.smoke Makefile targets
- Hermetic 5-minute quick-start command for local development

**Reuse-first approach:** No new implementations, just thin wrappers around existing Make targets and scripts.