### PR TITLE
docs: rc-gate-proof (expect gate failure)

### DIFF
--- a/docs/RC_GATE_PROOF.md
+++ b/docs/RC_GATE_PROOF.md
@@ -1,0 +1,1 @@
+# rc-gate-proof


### PR DESCRIPTION
Should fail build-pr without rc-freeze label.