### PR TITLE
docs(P9): real-data ingestion plan + hermetic env check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,3 +624,8 @@ codex.mcp.validate:
 	else \
 	  python3 -m json.tool ~/.cursor/mcp.json; \
 	fi
+
+ci.ingest.check:
+	@echo "[ci.ingest.check] start"
+	@if [ -n "$$CI" ]; then echo "HINT[ci.ingest.check]: CI detected; no DB/network. noop by design."; exit 0; fi
+	@echo "Local-only: set DATABASE_URL or PGHOST/PGDATABASE to run ingestion harness."

--- a/docs/phase9/INGESTION_PLAN.md
+++ b/docs/phase9/INGESTION_PLAN.md
@@ -1,0 +1,31 @@
+# Phase-9 — Real-Data Ingestion (Plan Only)
+
+Status: plan-only PR; CI hermetic (no network/DB). Local profiles documented.
+
+
+
+## Goals
+
+- Define ingestion harness interfaces (reader, validator, snapshot rotation).
+
+- Specify env: DATABASE_URL/PG* (local only), SNAPSHOT_DIR, MAX_ROWS (caps).
+
+- Prove hermeticity: `make ci.ingest.check` must HINT+exit 0 in CI.
+
+
+
+## Contracts
+
+- No writes to share/ in CI.
+
+- No outbound network in CI.
+
+- Rerun-safe: idempotent snapshots; deterministic seeds.
+
+
+
+## Next
+
+- P9-A: stub harness + local README
+
+- P9-B: validator + metrics envelope


### PR DESCRIPTION
Plan-only PR; adds docs/phase9/INGESTION_PLAN.md and ci.ingest.check.\nNo network/DB in CI; reuse-first; deterministic seeds.