### PR TITLE
feat(P9-B): validator + metrics envelope (local-only; hermetic CI guards)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 
 
-ingest.local.run:
-	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.run]: CI detected; noop."; exit 0; fi
-	@python scripts/ingest/stub_ingest.py
+ingest.local.validate:
+	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.validate]: CI detected; noop."; exit 0; fi
+	@python scripts/ingest/validate_snapshot.py
+
+ci.ingest.validate.check:
+	@echo "[ci.ingest.validate.check] start"
+	@if [ -n "$$CI" ]; then echo "HINT[ci.ingest.validate.check]: CI detected; noop by design."; exit 0; fi
+	@echo "Local-only validation; provide SNAPSHOT_FILE to validate different data."

--- a/docs/phase9/metrics.schema.json
+++ b/docs/phase9/metrics.schema.json
@@ -1,0 +1,59 @@
+{
+
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "P9 Metrics Envelope",
+
+  "type": "object",
+
+  "required": ["meta", "metrics"],
+
+  "properties": {
+
+    "meta": {
+
+      "type": "object",
+
+      "required": ["version", "source", "snapshot_path", "seed"],
+
+      "properties": {
+
+        "version": {"type": "string"},
+
+        "source": {"type": "string"},
+
+        "snapshot_path": {"type": "string"},
+
+        "seed": {"type": "integer"}
+
+      },
+
+      "additionalProperties": true
+
+    },
+
+    "metrics": {
+
+      "type": "object",
+
+      "required": ["nodes", "edges", "density"],
+
+      "properties": {
+
+        "nodes": {"type": "integer", "minimum": 0},
+
+        "edges": {"type": "integer", "minimum": 0},
+
+        "density": {"type": "number", "minimum": 0}
+
+      },
+
+      "additionalProperties": true
+
+    }
+
+  },
+
+  "additionalProperties": false
+
+}

--- a/scripts/ingest/validate_snapshot.py
+++ b/scripts/ingest/validate_snapshot.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json, os, sys, pathlib, math
+
+
+
+def is_ci() -> bool:
+
+    return any(os.getenv(k) for k in ("CI","GITHUB_ACTIONS","GITLAB_CI","BUILDKITE"))
+
+
+
+def load_snapshot(path: str) -> dict:
+
+    p = pathlib.Path(path)
+
+    if not p.exists():
+
+        print(f"ERR[p9.validate]: snapshot not found: {p}", file=sys.stderr)
+
+        sys.exit(2)
+
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+
+def compute_metrics(d: dict) -> dict:
+
+    nodes = len(d.get("nodes", []))
+
+    edges = len(d.get("edges", []))
+
+    # simple undirected density: 2E / (N(N-1)) ; define 0 if N<2
+
+    density = 0.0
+
+    if nodes >= 2:
+
+        density = (2.0 * edges) / (nodes * (nodes - 1))
+
+    return {"nodes": nodes, "edges": edges, "density": round(density, 6)}
+
+
+
+def main() -> int:
+
+    if is_ci():
+
+        print("HINT[p9.validate]: CI detected; noop (hermetic).")
+
+        return 0
+
+    snap = os.getenv("SNAPSHOT_FILE", "docs/phase9/example_snapshot.json")
+
+    seed = int(os.getenv("P9_SEED", "42"))
+
+    data = load_snapshot(snap)
+
+    metrics = compute_metrics(data)
+
+    envelope = {
+
+        "meta": {
+
+            "version": "0.1.0",
+
+            "source": "p9-validate-local",
+
+            "snapshot_path": snap,
+
+            "seed": seed
+
+        },
+
+        "metrics": metrics
+
+    }
+
+    print(json.dumps(envelope, indent=2))
+
+    return 0
+
+
+
+if __name__ == "__main__":
+
+    raise SystemExit(main())


### PR DESCRIPTION
Adds docs/phase9/metrics.schema.json and scripts/ingest/validate_snapshot.py. Local-only; CI no-ops via guards. No share/ writes; deterministic.