### PR TITLE
feat(P9-C): schema validation + ci.ingest.check + python3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,19 @@
 
 ingest.local.validate:
 	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.validate]: CI detected; noop."; exit 0; fi
-	@python scripts/ingest/validate_snapshot.py
+	@python3 scripts/ingest/validate_snapshot.py
 
 ci.ingest.validate.check:
 	@echo "[ci.ingest.validate.check] start"
 	@if [ -n "$$CI" ]; then echo "HINT[ci.ingest.validate.check]: CI detected; noop by design."; exit 0; fi
 	@echo "Local-only validation; provide SNAPSHOT_FILE to validate different data."
+
+ci.ingest.check:
+	@echo "[ci.ingest.check] start"
+	@if [ -n "$$CI" ]; then echo "HINT[ci.ingest.check]: CI detected; no DB/network. noop by design."; exit 0; fi
+	@echo "Local-only: set SNAPSHOT_FILE or DATABASE_URL to run ingestion harness."
+
+ingest.local.validate.schema:
+	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.validate.schema]: CI detected; noop."; exit 0; fi
+	@python3 scripts/ingest/validate_snapshot.py > /tmp/p9-envelope.json
+	@python3 scripts/ingest/validate_envelope_schema.py /tmp/p9-envelope.json

--- a/scripts/ingest/validate_envelope_schema.py
+++ b/scripts/ingest/validate_envelope_schema.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json, os, sys, pathlib
+
+REQ_META = {"version": str, "source": str, "snapshot_path": str, "seed": int}
+REQ_METRICS = {"nodes": int, "edges": int, "density": (int, float)}
+
+
+def is_ci() -> bool:
+    return any(os.getenv(k) for k in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE"))
+
+
+def type_ok(v, t):
+    if isinstance(t, tuple):
+        return isinstance(v, t)
+    return isinstance(v, t)
+
+
+def validate_envelope(env: dict) -> list[str]:
+    errs = []
+    if not isinstance(env, dict):
+        return ["Envelope must be an object"]
+    meta = env.get("meta")
+    metrics = env.get("metrics")
+    if not isinstance(meta, dict):
+        errs.append("meta must be an object")
+    else:
+        for k, t in REQ_META.items():
+            if k not in meta:
+                errs.append(f"meta.{k} missing")
+            elif not type_ok(meta[k], t):
+                errs.append(f"meta.{k} wrong type")
+    if not isinstance(metrics, dict):
+        errs.append("metrics must be an object")
+    else:
+        for k, t in REQ_METRICS.items():
+            if k not in metrics:
+                errs.append(f"metrics.{k} missing")
+            elif not type_ok(metrics[k], t):
+                errs.append(f"metrics.{k} wrong type")
+        # numeric constraints
+        if isinstance(metrics.get("nodes"), int) and metrics["nodes"] < 0:
+            errs.append("metrics.nodes < 0")
+        if isinstance(metrics.get("edges"), int) and metrics["edges"] < 0:
+            errs.append("metrics.edges < 0")
+        if isinstance(metrics.get("density"), (int, float)) and metrics["density"] < 0:
+            errs.append("metrics.density < 0")
+    return errs
+
+
+def main(argv=None) -> int:
+    if is_ci():
+        print("HINT[p9.schema]: CI detected; noop (hermetic).")
+        return 0
+    if len(sys.argv) < 2:
+        print(
+            "usage: python3 scripts/ingest/validate_envelope_schema.py <envelope.json>",
+            file=sys.stderr,
+        )
+        return 2
+    path = pathlib.Path(sys.argv[1])
+    if not path.exists():
+        print(f"ERR[p9.schema]: not found: {path}", file=sys.stderr)
+        return 2
+    env = json.loads(path.read_text(encoding="utf-8"))
+    errs = validate_envelope(env)
+    if errs:
+        print("SCHEMA_ERRORS:")
+        for e in errs:
+            print(f"- {e}")
+        return 3
+    print("SCHEMA_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingest/validate_snapshot.py
+++ b/scripts/ingest/validate_snapshot.py
@@ -1,21 +1,16 @@
 from __future__ import annotations
 
-import json, os, sys, pathlib, math
-
+import json, os, sys, pathlib
 
 
 def is_ci() -> bool:
-
-    return any(os.getenv(k) for k in ("CI","GITHUB_ACTIONS","GITLAB_CI","BUILDKITE"))
-
+    return any(os.getenv(k) for k in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE"))
 
 
 def load_snapshot(path: str) -> dict:
-
     p = pathlib.Path(path)
 
     if not p.exists():
-
         print(f"ERR[p9.validate]: snapshot not found: {p}", file=sys.stderr)
 
         sys.exit(2)
@@ -23,9 +18,7 @@ def load_snapshot(path: str) -> dict:
     return json.loads(p.read_text(encoding="utf-8"))
 
 
-
 def compute_metrics(d: dict) -> dict:
-
     nodes = len(d.get("nodes", []))
 
     edges = len(d.get("edges", []))
@@ -35,17 +28,13 @@ def compute_metrics(d: dict) -> dict:
     density = 0.0
 
     if nodes >= 2:
-
         density = (2.0 * edges) / (nodes * (nodes - 1))
 
     return {"nodes": nodes, "edges": edges, "density": round(density, 6)}
 
 
-
 def main() -> int:
-
     if is_ci():
-
         print("HINT[p9.validate]: CI detected; noop (hermetic).")
 
         return 0
@@ -59,21 +48,8 @@ def main() -> int:
     metrics = compute_metrics(data)
 
     envelope = {
-
-        "meta": {
-
-            "version": "0.1.0",
-
-            "source": "p9-validate-local",
-
-            "snapshot_path": snap,
-
-            "seed": seed
-
-        },
-
-        "metrics": metrics
-
+        "meta": {"version": "0.1.0", "source": "p9-validate-local", "snapshot_path": snap, "seed": seed},
+        "metrics": metrics,
     }
 
     print(json.dumps(envelope, indent=2))
@@ -81,7 +57,5 @@ def main() -> int:
     return 0
 
 
-
 if __name__ == "__main__":
-
     raise SystemExit(main())


### PR DESCRIPTION
Adds an in-repo schema validator (no external deps), restores ci.ingest.check (hermetic), and switches ingest targets to python3. No share/ writes, CI no-ops supported.