### PR TITLE
chore(P9-G): ingest.example.roll helper (local-only; CI-guarded)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ingest.example.roll:
 	@if [ -n "$$CI" ]; then echo "HINT[ingest.example.roll]: CI detected; noop."; exit 0; fi
 	@mkdir -p docs/phase9/snapshots
-	@SEED="$$${P9_SEED:-42}"; D=$$(date +%Y%m%d); OUT=docs/phase9/snapshots/$${D}_example_seed$${SEED}.json; \
+	@SEED=$${P9_SEED:-42}; D=$$(date +%Y%m%d); OUT=docs/phase9/snapshots/$${D}_example_seed$${SEED}.json; \
 	  if [ -f "$$OUT" ] && [ "$$${FORCE:-0}" != "1" ]; then \
 	    echo "HINT[ingest.example.roll]: exists $$OUT (use FORCE=1 to overwrite)"; \
 	  else \


### PR DESCRIPTION
Adds a small Make helper to roll the committed example snapshot into a dated file under docs/phase9/snapshots/. Local-only; CI prints HINT and exits 0. No share/ writes or pipeline changes.