### PR TITLE
docs(P9-L): ingestion envelope fields + draft schema (docs-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ make ingest.local.validate.schema
 See `docs/phase9/VALIDATION_README.md` for env knobs (SNAPSHOT_FILE, P9_SEED).
 
 - Snapshot prep guide: see `docs/phase9/SNAPSHOTS.md`.
+
+- Ingestion envelope fields (plan): see `docs/phase9/ENVELOPE_FIELDS.md`.

--- a/docs/phase9/ENVELOPE_FIELDS.md
+++ b/docs/phase9/ENVELOPE_FIELDS.md
@@ -1,0 +1,43 @@
+# Ingestion Envelope — Fields (Plan Only)
+
+Linked scope: see Issue #160 (approved P9-H).
+
+## Meta
+
+- `version` (string) — semantic; default "0.1.0"
+
+- `source` (string) — "p9-envelope-local" or descriptive
+
+- `snapshot_path` (string) — local path used to build envelope
+
+- `seed` (integer) — deterministic seed
+
+- `created_at` (string, ISO8601) — optional (may be added later)
+
+## Nodes
+
+- `id` (string) — required; canonical identifier
+
+- `label` (string, ≤120) — normalized (spaces collapsed)
+
+- `type` (string, ≤40) — normalized; optional
+
+- `attrs` (object) — optional, bounded keys/values (TBD caps)
+
+## Edges
+
+- `src` (string) — required; node id
+
+- `dst` (string) — required; node id
+
+- `rel_type` (string, ≤40) — normalized relation label
+
+- `weight` (number [0..1]) — optional; clamped
+
+## Constraints & Notes
+
+- No external network/DB in CI; local-only build paths.
+
+- Deterministic: fixed seed; stable normalization.
+
+- Future: provenance `prov` block (TBD), audit trail IDs (TBD).

--- a/docs/phase9/ingest_envelope.schema.draft.json
+++ b/docs/phase9/ingest_envelope.schema.draft.json
@@ -1,0 +1,97 @@
+{
+
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Ingestion Envelope (Draft)",
+
+  "type": "object",
+
+  "required": ["meta", "nodes", "edges"],
+
+  "properties": {
+
+    "meta": {
+
+      "type": "object",
+
+      "required": ["version", "source", "snapshot_path", "seed"],
+
+      "properties": {
+
+        "version": {"type": "string"},
+
+        "source": {"type": "string"},
+
+        "snapshot_path": {"type": "string"},
+
+        "seed": {"type": "integer"},
+
+        "created_at": {"type": "string"}
+
+      },
+
+      "additionalProperties": true
+
+    },
+
+    "nodes": {
+
+      "type": "array",
+
+      "items": {
+
+        "type": "object",
+
+        "required": ["id", "label"],
+
+        "properties": {
+
+          "id": {"type": "string"},
+
+          "label": {"type": "string", "maxLength": 120},
+
+          "type": {"type": "string", "maxLength": 40},
+
+          "attrs": {"type": "object"}
+
+        },
+
+        "additionalProperties": true
+
+      }
+
+    },
+
+    "edges": {
+
+      "type": "array",
+
+      "items": {
+
+        "type": "object",
+
+        "required": ["src", "dst", "rel_type"],
+
+        "properties": {
+
+          "src": {"type": "string"},
+
+          "dst": {"type": "string"},
+
+          "rel_type": {"type": "string", "maxLength": 40},
+
+          "weight": {"type": "number", "minimum": 0, "maximum": 1}
+
+        },
+
+        "additionalProperties": true
+
+      }
+
+    }
+
+  },
+
+  "additionalProperties": false
+
+}


### PR DESCRIPTION
Defines first real ingestion envelope fields and a draft JSON schema. Docs-only; no CI usage. Linked to Issue #160 scope decision.