### PR TITLE
chore(P9-O.1): envelope meta+checksum helper (LOCAL ONLY)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,8 @@ ingest.local.envelope.show:
 	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.envelope.show]: CI detected; noop."; exit 0; fi
 	@OUT_FILE=/tmp/p9-ingest-envelope.json P9_CREATED_AT=2025-11-02T00:00:00 \
 	  PYTHONPATH=. python3 scripts/ingest/build_envelope.py > /dev/null && head -40 /tmp/p9-ingest-envelope.json
+
+ingest.local.envelope.meta:
+	@if [ -n "$$CI" ]; then echo "HINT[ingest.local.envelope.meta]: CI detected; noop."; exit 0; fi
+	@OUT_FILE=/tmp/p9-ingest-envelope.json python3 scripts/ingest/build_envelope.py > /dev/null
+	@python3 scripts/ingest/show_meta.py

--- a/scripts/ingest/show_meta.py
+++ b/scripts/ingest/show_meta.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json, os, sys, hashlib, pathlib
+
+
+def is_ci() -> bool:
+    return any(os.getenv(k) for k in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE"))
+
+
+def main() -> int:
+    if is_ci():
+        print("HINT[ingest.meta]: CI detected; noop (hermetic).")
+        return 0
+
+    out = os.getenv("OUT_FILE", "/tmp/p9-ingest-envelope.json")
+    p = pathlib.Path(out)
+    if not p.exists():
+        print(f"ERR[ingest.meta]: envelope not found: {p}", file=sys.stderr)
+        return 2
+
+    b = p.read_bytes()
+    meta = json.loads(b).get("meta", {})
+    print("META:", json.dumps(meta, indent=2))
+    print("SHA256:", hashlib.sha256(b).hexdigest())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds scripts/ingest/show_meta.py and make ingest.local.envelope.meta (CI-guarded). Hermetic; no share/ writes.