### PR TITLE
feat(P10-B): envelope loader + placeholder stats view (local-only)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gemantria Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,0 +1,16 @@
+// P10-B minimal app
+
+import React from 'react';
+import { EnvelopeStats } from '../components/EnvelopeStats';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>Gemantria Dashboard (P10-B)</h1>
+      <p>Local-only visualization of Phase-9 envelopes</p>
+      <EnvelopeStats />
+    </div>
+  );
+}
+
+export default App;

--- a/ui/src/app/index.ts
+++ b/ui/src/app/index.ts
@@ -1,0 +1,3 @@
+// App exports
+
+export { default as App } from './App';

--- a/ui/src/components/EnvelopeStats.tsx
+++ b/ui/src/components/EnvelopeStats.tsx
@@ -1,0 +1,45 @@
+// Placeholder stats view (P10-B)
+
+import React, { useEffect, useState } from 'react';
+import { Envelope } from '../types/envelope';
+import { loadEnvelope, getEnvelopeStats } from '../lib/loadEnvelope';
+
+export function EnvelopeStats() {
+  const [envelope, setEnvelope] = useState<Envelope | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadEnvelope().then((data) => {
+      setEnvelope(data);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) {
+    return <div>Loading envelope...</div>;
+  }
+
+  if (!envelope) {
+    return (
+      <div style={{ padding: '20px', border: '1px solid #ccc', margin: '20px' }}>
+        <h3>Envelope Not Found</h3>
+        <p>Run <code>make ingest.local.envelope</code> to generate /tmp/p9-ingest-envelope.json</p>
+      </div>
+    );
+  }
+
+  const stats = getEnvelopeStats(envelope);
+
+  return (
+    <div style={{ padding: '20px', border: '1px solid #ccc', margin: '20px' }}>
+      <h3>Envelope Stats</h3>
+      <ul>
+        <li>Nodes: {stats.nodeCount}</li>
+        <li>Edges: {stats.edgeCount}</li>
+        <li>Version: {stats.version}</li>
+        <li>Source: {stats.source}</li>
+        <li>Created: {stats.createdAt}</li>
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/lib/loadEnvelope.ts
+++ b/ui/src/lib/loadEnvelope.ts
@@ -1,0 +1,30 @@
+// Local envelope loader (Phase-9 data source)
+
+import { Envelope } from '../types/envelope';
+
+const ENVELOPE_PATH = '/tmp/p9-ingest-envelope.json';
+
+export async function loadEnvelope(): Promise<Envelope | null> {
+  try {
+    const response = await fetch(ENVELOPE_PATH);
+    if (!response.ok) {
+      console.warn(`Envelope not found at ${ENVELOPE_PATH}`);
+      return null;
+    }
+    const data = await response.json();
+    return data as Envelope;
+  } catch (error) {
+    console.warn('Failed to load envelope:', error);
+    return null;
+  }
+}
+
+export function getEnvelopeStats(envelope: Envelope) {
+  return {
+    nodeCount: envelope.nodes.length,
+    edgeCount: envelope.edges.length,
+    version: envelope.meta.version,
+    source: envelope.meta.source,
+    createdAt: envelope.meta.created_at,
+  };
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,11 @@
+// P10-B entry point
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './app';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/ui/src/types/envelope.ts
+++ b/ui/src/types/envelope.ts
@@ -1,0 +1,29 @@
+// Phase-9 envelope types (minimal for P10-B)
+
+export interface EnvelopeNode {
+  id: string;
+  label: string;
+  type?: string;
+  attrs?: Record<string, any>;
+}
+
+export interface EnvelopeEdge {
+  src: string;
+  dst: string;
+  rel_type: string;
+  [key: string]: any;
+}
+
+export interface EnvelopeMeta {
+  version: string;
+  source: string;
+  snapshot_path: string;
+  seed: number;
+  created_at: string;
+}
+
+export interface Envelope {
+  meta: EnvelopeMeta;
+  nodes: EnvelopeNode[];
+  edges: EnvelopeEdge[];
+}


### PR DESCRIPTION
Adds TypeScript types, envelope loader, and minimal stats component that displays node/edge counts from /tmp/p9-ingest-envelope.json. No CI/Node changes; local dev only.